### PR TITLE
this makes using oauth to make POST requests to the twitter streaming API much easier

### DIFF
--- a/lib/oauth.js
+++ b/lib/oauth.js
@@ -248,6 +248,9 @@ exports.OAuth.prototype._performSecureRequest= function( oauth_token, oauth_toke
     request.end();
   }
   else {
+    if( method == "POST" && post_body != null && post_body != "" ) {
+      request.write(post_body);
+    }
     return request;
   }
   


### PR DESCRIPTION
I don't think there is any downside to this patch. if a user wants to POST something in a streaming way, they will be able to not send a post param to oauth.post, and get the current behavior. but if you do send a post, and want a streaming response, this makes it much easier by handling the content-type, -length, etc.

Thanks!

Chris
