### PR TITLE
Fixing the way signed parameters are encoded

### DIFF
--- a/lib/oauth.js
+++ b/lib/oauth.js
@@ -92,16 +92,15 @@ exports.OAuth.prototype._normaliseRequestParams= function(arguments) {
   var args= "";
   for(var i=0;i<argument_pairs.length;i++) {
       args+= this._encodeData( argument_pairs[i][0] );
-      args+= "="
+      args+= "%3D"
       args+= this._encodeData( argument_pairs[i][1] );
-      if( i < argument_pairs.length-1 ) args+= "&";
+      if( i < argument_pairs.length-1 ) args+= "%26";
   }     
   return args;
 }
 
 exports.OAuth.prototype._createSignatureBase= function(method, url, parameters) {
   url= this._encodeData( this._normalizeUrl(url) ); 
-  parameters= this._encodeData( parameters );
   return method.toUpperCase() + "&" + url + "&" + parameters;
 }
 


### PR DESCRIPTION
Hi. I was having a problem using node-oauth with Twitter SiteStreams.

I found the bug to be happening when I had a comma on the URL parameters, like "follow=123,324,45".

Checked the code and verified it was a double encoding bug. I think I've fixed it on my branch, here is the patch. Tell me what you think!

Thank you!
