### PR TITLE
hack to support Google's scope param

### DIFF
--- a/lib/oauth.js
+++ b/lib/oauth.js
@@ -202,7 +202,7 @@ exports.OAuth.prototype._performSecureRequest= function( oauth_token, oauth_toke
   for( var i= 0 ; i < orderedParameters.length; i++) { 
      // Whilst the all the parameters should be included within the signature, only the oauth_ arguments
      // should appear within the authorization header.
-     if( orderedParameters[i][0].match('^oauth_') == "oauth_") {
+     if( orderedParameters[i][0].match('^oauth_') == "oauth_" || orderedParameters[i][0] === 'scope') {
       authHeader+= this._encodeData(orderedParameters[i][0])+"=\""+ this._encodeData(orderedParameters[i][1])+"\",";
      }
   }
@@ -224,7 +224,7 @@ exports.OAuth.prototype._performSecureRequest= function( oauth_token, oauth_toke
   if( !parsedUrl.pathname  || parsedUrl.pathname == "" ) parsedUrl.pathname ="/";
   if( parsedUrl.query ) path= parsedUrl.pathname + "?"+ parsedUrl.query ;
   else path= parsedUrl.pathname;
-  
+
   var request = oauthProvider.request(method,  path , headers);
   if( callback ) {
     var data=""; 
@@ -312,7 +312,7 @@ exports.OAuth.prototype.getOAuthRequestToken= function(extraParams, callback) {
   // Callbacks are 1.0A related 
   if( this._authorize_callback ) {
     extraParams["oauth_callback"]= this._authorize_callback;
-  }  
+  }
   this._performSecureRequest( null, null, "POST", this._requestUrl, extraParams, "", null, function(error, data, response) {
     if( error ) callback(error);
     else {


### PR DESCRIPTION
Hi,

Google has a non-standard 'scope' param that they require:
http://code.google.com/apis/accounts/docs/OAuth_ref.html#RequestToken

This hack allows us to pass it through if you add scope to the extraParams object passed into getOAuthRequestToken()

There's probably a more elegant way to do this, but this worked for me and I was able to login via Google.

cheers,

-- James
