### PR TITLE
Renaming variable sshEnabled -> sslEnabled

### DIFF
--- a/lib/oauth.js
+++ b/lib/oauth.js
@@ -193,8 +193,8 @@ exports.OAuth.prototype._getNonce= function(nonceSize) {
    return result.join('');
 }
 
-exports.OAuth.prototype._createClient= function( port, hostname, sshEnabled, credentials ) {
-  return http.createClient(port, hostname, sshEnabled, credentials);
+exports.OAuth.prototype._createClient= function( port, hostname, sslEnabled, credentials ) {
+  return http.createClient(port, hostname, sslEnabled, credentials);
 }
 
 exports.OAuth.prototype._prepareParameters= function( oauth_token, oauth_token_secret, method, url, extra_params ) {


### PR DESCRIPTION
Hi,

While browsing the code I stumbled upon the variable <code>sshEnabled</code>. I guess this is a typo and should be <code>sslEnabled</code>.
