### PR TITLE
POST requests should have query params in the body

### DIFF
--- a/lib/oauth2.js
+++ b/lib/oauth2.js
@@ -36,22 +36,29 @@ exports.OAuth2.prototype._request= function(method, url, headers, access_token, 
   }
   realHeaders['Host']= parsedUrl.host;
 
-  //TODO: Content length should be dynamic when dealing with POST methods....
-  realHeaders['Content-Length']= 0;
   if( access_token ) {
     if( ! parsedUrl.query ) parsedUrl.query= {};
     parsedUrl.query["access_token"]= access_token;
   }
 
+  var body;
   var result= "";
 
   var options = {
     host:parsedUrl.hostname,
     port: parsedUrl.port,
-    path: parsedUrl.pathname + "?" + querystring.stringify(parsedUrl.query),
     method: method,
     headers: realHeaders
   };
+
+  if( method == "POST" ) {
+    body = querystring.stringify(parsedUrl.query);
+    options.path = parsedUrl.pathname;
+  } else {
+    options.path = parsedUrl.pathname + "?" + querystring.stringify(parsedUrl.query);
+  }
+
+  options.headers['Content-Length'] = body ? body.length : 0;
 
   request = https.request(options, function (response) { 
     response.addListener("data", function (chunk) {
@@ -70,7 +77,7 @@ exports.OAuth2.prototype._request= function(method, url, headers, access_token, 
     callback(e);
   });
 
-  request.end();
+  request.end(body);
 } 
 
 


### PR DESCRIPTION
Some sites (like Instagram) will ignore the query string parameters for POST requests, as they're expecting them in the request body.
