### PR TITLE
Allows custom headers in http requests

### DIFF
--- a/lib/oauth.js
+++ b/lib/oauth.js
@@ -252,8 +252,14 @@ exports.OAuth.prototype._prepareParameters= function( oauth_token, oauth_token_s
   return orderedParameters;
 }
 
-exports.OAuth.prototype._performSecureRequest= function( oauth_token, oauth_token_secret, method, url, extra_params, post_body, post_content_type,  callback ) {
+exports.OAuth.prototype._performSecureRequest= function( oauth_token, oauth_token_secret, method, url, extra_params, post_body, post_content_type, headers, callback ) {
   var orderedParameters= this._prepareParameters(oauth_token, oauth_token_secret, method, url, extra_params);
+  
+  // Hack for custom headers whithout breaking compatibility.
+  if (typeof headers == 'function') {
+	  callback = headers;
+	  delete headers;
+  }
 
   if( !post_content_type ) {
     post_content_type= "application/x-www-form-urlencoded";
@@ -262,7 +268,7 @@ exports.OAuth.prototype._performSecureRequest= function( oauth_token, oauth_toke
   if( parsedUrl.protocol == "http:" && !parsedUrl.port ) parsedUrl.port= 80;
   if( parsedUrl.protocol == "https:" && !parsedUrl.port ) parsedUrl.port= 443;
 
-  var headers= {};
+  var headers= headers || {};
   headers["Authorization"]= this._buildAuthorizationHeaders(orderedParameters);
   headers["Host"] = parsedUrl.host
 
@@ -285,9 +291,6 @@ exports.OAuth.prototype._performSecureRequest= function( oauth_token, oauth_toke
 
   headers["Content-length"]= post_body ? post_body.length : 0; //Probably going to fail if not posting ascii
   headers["Content-Type"]= post_content_type;
-
-  // Required for linkedin. Will think of a better way soon.
-  headers["x-li-format"]= "json";
    
   var path;
   if( !parsedUrl.pathname  || parsedUrl.pathname == "" ) parsedUrl.pathname ="/";
@@ -336,7 +339,7 @@ exports.OAuth.prototype._performSecureRequest= function( oauth_token, oauth_toke
   return;
 }
 
-exports.OAuth.prototype.getOAuthAccessToken= function(oauth_token, oauth_token_secret, oauth_verifier,  callback) {
+exports.OAuth.prototype.getOAuthAccessToken= function(oauth_token, oauth_token_secret, oauth_verifier, callback) {
   var extraParams= {};
   if( typeof oauth_verifier == "function" ) {
     callback= oauth_verifier;
@@ -358,19 +361,19 @@ exports.OAuth.prototype.getOAuthAccessToken= function(oauth_token, oauth_token_s
 }
 
 // Deprecated
-exports.OAuth.prototype.getProtectedResource= function(url, method, oauth_token, oauth_token_secret, callback) {
-  this._performSecureRequest( oauth_token, oauth_token_secret, method, url, null, "", null, callback );
+exports.OAuth.prototype.getProtectedResource= function(url, method, oauth_token, oauth_token_secret, headers, callback) {
+  this._performSecureRequest( oauth_token, oauth_token_secret, method, url, null, "", null, headers, callback );
 }
 
-exports.OAuth.prototype.delete= function(url, oauth_token, oauth_token_secret, callback) {
-  return this._performSecureRequest( oauth_token, oauth_token_secret, "DELETE", url, null, "", null, callback );
+exports.OAuth.prototype.delete= function(url, oauth_token, oauth_token_secret, headers, callback) {
+  return this._performSecureRequest( oauth_token, oauth_token_secret, "DELETE", url, null, "", null, headers, callback );
 }
 
-exports.OAuth.prototype.get= function(url, oauth_token, oauth_token_secret, callback) {
-  return this._performSecureRequest( oauth_token, oauth_token_secret, "GET", url, null, "", null, callback );
+exports.OAuth.prototype.get= function(url, oauth_token, oauth_token_secret, headers, callback) {
+  return this._performSecureRequest( oauth_token, oauth_token_secret, "GET", url, null, "", null, headers, callback );
 }
 
-exports.OAuth.prototype._putOrPost= function(method, url, oauth_token, oauth_token_secret, post_body, post_content_type, callback) {
+exports.OAuth.prototype._putOrPost= function(method, url, oauth_token, oauth_token_secret, post_body, post_content_type, headers, callback) {
   var extra_params= null;
   if( typeof post_content_type == "function" ) {
     callback= post_content_type;
@@ -381,16 +384,16 @@ exports.OAuth.prototype._putOrPost= function(method, url, oauth_token, oauth_tok
     extra_params= post_body;
     post_body= null;
   }
-  return this._performSecureRequest( oauth_token, oauth_token_secret, method, url, extra_params, post_body, post_content_type, callback );
+  return this._performSecureRequest( oauth_token, oauth_token_secret, method, url, extra_params, post_body, post_content_type, headers, callback );
 }
  
 
-exports.OAuth.prototype.put= function(url, oauth_token, oauth_token_secret, post_body, post_content_type, callback) {
-  return this._putOrPost("PUT", url, oauth_token, oauth_token_secret, post_body, post_content_type, callback);
+exports.OAuth.prototype.put= function(url, oauth_token, oauth_token_secret, post_body, post_content_type, headers, callback) {
+  return this._putOrPost("PUT", url, oauth_token, oauth_token_secret, post_body, post_content_type, headers, callback);
 }
 
-exports.OAuth.prototype.post= function(url, oauth_token, oauth_token_secret, post_body, post_content_type, callback) {
-  return this._putOrPost("POST", url, oauth_token, oauth_token_secret, post_body, post_content_type, callback);
+exports.OAuth.prototype.post= function(url, oauth_token, oauth_token_secret, post_body, post_content_type, headers, callback) {
+  return this._putOrPost("POST", url, oauth_token, oauth_token_secret, post_body, post_content_type, headers, callback);
 }
 
 exports.OAuth.prototype.getOAuthRequestToken= function(extraParams, callback) {


### PR DESCRIPTION
I changed the http request functions to allow an extra headers object before the final callback. I added a little hack in the _performSecureRequest() function to prevent this from breaking compatibility.
