### PR TITLE
1.  Start with a url like:  http://somehost.com?foo=ONE&foo=TWO&foo=three

### DIFF
--- a/lib/oauth.js
+++ b/lib/oauth.js
@@ -131,7 +131,9 @@ exports.OAuth.prototype._normaliseRequestParams= function(arguments) {
   var argument_pairs= this._makeArrayOfArgumentsHash(arguments);
   // First encode them #3.4.1.3.2 .1
   for(var i=0;i<argument_pairs.length;i++) {
-    argument_pairs[i][0]= this._encodeData( argument_pairs[i][0] );
+    // if multiple params exist with same name, they are represented as:  foo[0], foo[1], foo[2]
+    // when encoding the "name" part of the pair, do not include the bracket portion.  Hence I added: .match(/^[^[]*/)[0]
+    argument_pairs[i][0]= this._encodeData( argument_pairs[i][0].match(/^[^[]*/)[0] );
     argument_pairs[i][1]= this._encodeData( argument_pairs[i][1] );
   }
   

--- a/tests/oauth.js
+++ b/tests/oauth.js
@@ -83,6 +83,15 @@ vows.describe('OAuth').addBatch({
           "c2" :  ""};
         var normalisedParameterString= oa._normaliseRequestParams(parameters);
         assert.equal(normalisedParameterString, "a2=r%20b&a3=2%20q&a3=a&b5=%3D%253D&c%40=&c2=&oauth_consumer_key=9djdj82h48djs9d2&oauth_nonce=7d8f3e4a&oauth_signature_method=HMAC-SHA1&oauth_timestamp=137131201&oauth_token=kkk9d7dh3k39sjv7");
+      },
+      'accept multiple parameters with same name "foo" ' : function(oa) {
+        var parameters= { 
+          'foo[0]': 'one',
+          'foo[1]': 'two',
+          'foo[2]': 'three',
+          count: '100' };
+        var normalisedParameterString= oa._normaliseRequestParams(parameters);
+        assert.equal(normalisedParameterString, "count=100&foo=one&foo=three&foo=two");
       }
     },
     'When preparing the parameters for use in signing': {


### PR DESCRIPTION
Hi,  I had problems getting the signature to work when I had multiple parameters with the same name.  The following patch resolved my problem.  Thanks!
1.  Start with a url like:  http://somehost.com?foo=ONE&foo=TWO&foo=three&count=100
2. oauth.js, _prepareParameters line 245 converts this to:
   
   {'foo[0]': 'ONE', 
   'foo[1]': 'TWO', 
   'foo[2]': 'THREE', 
   count: '100' }
3.  oauth.js, _normaliseRequestParams line 137 needs to be fixed to NOT include the bracket notation in the string-to-sign:
   
   argument_pairs[i][0]= this._encodeData( argument_pairs[i][0]);
   
   changed to 
   
   argument_pairs[i][0]= this._encodeData( argument_pairs[i][0].match(/^[^[]*/)[0] );
