### PR TITLE
Improved error handling to take into account other HTTP codes in the 200 range

### DIFF
--- a/lib/oauth.js
+++ b/lib/oauth.js
@@ -308,7 +308,7 @@ exports.OAuth.prototype._performSecureRequest= function( oauth_token, oauth_toke
         data+=chunk;
       });
       response.on('end', function () {
-        if( response.statusCode != 200 ) {
+        if( response.statusCode < 200 || response.statusCode >= 300 ) {
           callback({ statusCode: response.statusCode, data: data });
         } else {
           callback(null, data, response);


### PR DESCRIPTION
There are more "successful" HTTP status codes than just 200. Common cases are 201 (especially), 202, and 204.

I also feel HTTP codes in the 300 range are not "errors" either, but to maintain backwards compatibility I left them alone for now.
