### PR TITLE
Added ability to add extra parameters for all oauth requests: get, put, post, delete

### DIFF
--- a/lib/oauth.js
+++ b/lib/oauth.js
@@ -416,14 +416,17 @@ exports.OAuth.prototype.get= function(url, oauth_token, oauth_token_secret, extr
 }
 
 exports.OAuth.prototype._putOrPost= function(method, url, oauth_token, oauth_token_secret, extra_params, post_body, post_content_type, callback) {
-  var extra_params= null;
   if( typeof post_content_type == "function" ) {
     callback= post_content_type;
     post_content_type= null;
   }
   if( typeof post_body != "string" ) {
+    var tmpExtraParams = extra_params;
     post_content_type= "application/x-www-form-urlencoded"
     extra_params= post_body;
+     for(var key in tmpExtraParams ) {
+       extra_params[key] = tmpExtraParams[key];
+     };
     post_body= null;
   }
   return this._performSecureRequest( oauth_token, oauth_token_secret, method, url, extra_params, post_body, post_content_type, callback );


### PR DESCRIPTION
The helper methods (get,put,post,delete) would not allow to pass in extra parameters. I've made the changes so that one can pass in extra parameters if they want to.

It changes the API a bit as an extra parameter is added to these methods but I feel like it was a needed feature.
