### PR TITLE
Using regex match for 2xx on HTTP status code. Used similar matching conv

### DIFF
--- a/lib/oauth.js
+++ b/lib/oauth.js
@@ -350,7 +350,8 @@ exports.OAuth.prototype._performSecureRequest= function( oauth_token, oauth_toke
         data+=chunk;
       });
       response.on('end', function () {
-        if( response.statusCode != 200 ) {
+        var m = response.statusCode.toString().match(/^2[0-9]{2}$/);
+        if( !m ) {
           // Follow 302 redirects with Location HTTP header
           if(response.statusCode == 302 && response.headers && response.headers.location) {
             self._performSecureRequest( oauth_token, oauth_token_secret, method, response.headers.location, extra_params, post_body, post_content_type,  callback);


### PR DESCRIPTION
Using regex match for 2xx on HTTP status code. Used similar matching convention in other part of source. (var m)
