### PR TITLE
Adds http proxy support

### DIFF
--- a/lib/oauth.js
+++ b/lib/oauth.js
@@ -5,7 +5,7 @@ var crypto= require('crypto'),
     URL= require('url'),
     querystring= require('querystring'); 
 
-exports.OAuth= function(requestUrl, accessUrl, consumerKey, consumerSecret, version, authorize_callback, signatureMethod, nonceSize, customHeaders, proxyHost, proxyPort) {
+exports.OAuth= function(requestUrl, accessUrl, consumerKey, consumerSecret, version, authorize_callback, signatureMethod, nonceSize, customHeaders, proxySettings) {
   this._isEcho = false;
 
   this._requestUrl= requestUrl;
@@ -27,8 +27,7 @@ exports.OAuth= function(requestUrl, accessUrl, consumerKey, consumerSecret, vers
   this._headers= customHeaders || {"Accept" : "*/*",
                                    "Connection" : "close",
                                    "User-Agent" : "Node authentication"}
-  this._proxyHost= proxyHost;
-  this._proxyPort= proxyPort;
+  this._proxySettings= proxySettings;
 };
 
 exports.OAuthEcho= function(realm, verify_credentials, consumerKey, consumerSecret, version, signatureMethod, nonceSize, customHeaders) {
@@ -224,13 +223,16 @@ exports.OAuth.prototype._getNonce= function(nonceSize) {
 }
 
 exports.OAuth.prototype._createClient= function( port, hostname, method, path, headers, sslEnabled ) {
-  if( typeof(this._proxyHost) == "string" ) {
-    if( typeof(this._proxyPort) == "undefined" ) {
+  if( typeof(this._proxySettings) == "object" ) {
+    if( typeof(this._proxySettings.host) == "undefined") {
+      throw new Error('Proxy host not defined');
+    }
+    if( typeof(this._proxySettings.port) == "undefined" ) {
       throw new Error("Proxy port not defined");
     }
     path = "http" + (sslEnabled ? "s" : "") + "://" + hostname + ":" + port + path;
-    hostname = this._proxyHost;
-    port = this._proxyPort;
+    hostname = this._proxySettings.host;
+    port = this._proxySettings.port;
   }
   var options = {
     host: hostname,


### PR DESCRIPTION
All of our outbound traffic goes through a basic http proxy.  This patch enables node-oauth to connect through the proxy.
