### PR TITLE
Add support for 301 redirects

### DIFF
--- a/lib/oauth.js
+++ b/lib/oauth.js
@@ -353,8 +353,8 @@ exports.OAuth.prototype._performSecureRequest= function( oauth_token, oauth_toke
         if ( response.statusCode >= 200 && response.statusCode <= 299 ) {
           callback(null, data, response);
         } else {
-          // Follow 302 redirects with Location HTTP header
-          if(response.statusCode == 302 && response.headers && response.headers.location) {
+          // Follow 301 or 302 redirects with Location HTTP header
+          if((response.statusCode == 301 || response.statusCode == 302) && response.headers && response.headers.location) {
             self._performSecureRequest( oauth_token, oauth_token_secret, method, response.headers.location, extra_params, post_body, post_content_type,  callback);
           }
           else {


### PR DESCRIPTION
As per this ticket (https://github.com/ciaranj/node-oauth/issues/51) I've added 301 redirect support to the existing 302 area. Also created two tests for proper coverage of 301's.
