### PR TITLE
Reimplemented configurable http method for token requests using setClientOptions

### DIFF
--- a/lib/oauth.js
+++ b/lib/oauth.js
@@ -28,6 +28,8 @@ exports.OAuth= function(requestUrl, accessUrl, consumerKey, consumerSecret, vers
   this._headers= customHeaders || {"Accept" : "*/*",
                                    "Connection" : "close",
                                    "User-Agent" : "Node authentication"}
+  this._clientOptions= this._defaultClientOptions= {"requestTokenHttpMethod": "POST",
+                                                    "accessTokenHttpMethod": "POST"};
 };
 
 exports.OAuthEcho= function(realm, verify_credentials, consumerKey, consumerSecret, version, signatureMethod, nonceSize, customHeaders) {
@@ -402,6 +404,22 @@ exports.OAuth.prototype._performSecureRequest= function( oauth_token, oauth_toke
   return;
 }
 
+exports.OAuth.prototype.setClientOptions= function(options) {
+  var key,
+      mergedOptions= {},
+      hasOwnProperty= Object.prototype.hasOwnProperty;
+
+  for( key in this._defaultClientOptions ) {
+    if( !hasOwnProperty.call(options, key) ) {
+      mergedOptions[key]= this._defaultClientOptions[key];
+    } else {
+      mergedOptions[key]= options[key];
+    }
+  }
+
+  this._clientOptions= mergedOptions;
+};
+
 exports.OAuth.prototype.getOAuthAccessToken= function(oauth_token, oauth_token_secret, oauth_verifier,  callback) {
   var extraParams= {};
   if( typeof oauth_verifier == "function" ) {
@@ -410,7 +428,7 @@ exports.OAuth.prototype.getOAuthAccessToken= function(oauth_token, oauth_token_s
     extraParams.oauth_verifier= oauth_verifier;
   }
   
-   this._performSecureRequest( oauth_token, oauth_token_secret, "POST", this._accessUrl, extraParams, null, null, function(error, data, response) {
+   this._performSecureRequest( oauth_token, oauth_token_secret, this._clientOptions.accessTokenHttpMethod, this._accessUrl, extraParams, null, null, function(error, data, response) {
          if( error ) callback(error);
          else {
            var results= querystring.parse( data );
@@ -475,43 +493,17 @@ exports.OAuth.prototype.post= function(url, oauth_token, oauth_token_secret, pos
  * 2) As above but allows for provision of extra parameters to be sent as part of the query to the server (POST).
  *  getOAuthRequestToken( extraParams, callbackFunction )
  *
- * 3) A basic request with no extra parameters, using a specified HTTP method
- *  getOAuthRequestToken( httpMethod, callbackFunction )
- *
- * 4) A request with extra parameters that can using a specified HTTP method
- *  getOAuthRequestToken(  httpMethod, extraParams, callbackFunction )
  **/
-exports.OAuth.prototype.getOAuthRequestToken= function( httpMethod, extraParams, callback ) {
-
-  if( typeof httpMethod == "function" ){ // 1
-    callback = httpMethod;
-    extraParams = {};
-    httpMethod= "POST";
-  } else {
-    if( typeof httpMethod == "string" && arguments.length == 2 ) {// 3 
-      callback= extraParams;
-      extraParams= {};
-    }
-    else if( typeof httpMethod == "string" && arguments.length == 3 ) {// 4
-      // the given arguments will match!
-    }
-    else { //2
-      if( arguments.length != 2) {
-        throw new Error("Invalid arguments passed.");
-      }
-      else {
-        callback= extraParams;
-        extraParams= httpMethod;
-        httpMethod= "GET";
-      }
-    }
-  }
-
+exports.OAuth.prototype.getOAuthRequestToken= function( extraParams, callback ) {
+   if( typeof extraParams == "function" ){
+     callback = extraParams;
+     extraParams = {};
+   }
   // Callbacks are 1.0A related 
   if( this._authorize_callback ) {
     extraParams["oauth_callback"]= this._authorize_callback;
   }
-  this._performSecureRequest( null, null, httpMethod, this._requestUrl, extraParams, null, null, function(error, data, response) {
+  this._performSecureRequest( null, null, this._clientOptions.requestTokenHttpMethod, this._requestUrl, extraParams, null, null, function(error, data, response) {
     if( error ) callback(error);
     else {
       var results= querystring.parse(data);

--- a/tests/oauth.js
+++ b/tests/oauth.js
@@ -141,12 +141,33 @@ vows.describe('OAuth').addBatch({
           oa._performSecureRequest= function(){ return this.requestArguments = arguments; }
           return oa;
         },
-        'Use the provided HTTP method': function(oa) {
-          oa.getOAuthRequestToken("GET", function() {});
+        'Use the HTTP method in the client options': function(oa) {
+          oa.setClientOptions({ requestTokenHttpMethod: "GET" });
+          oa.getOAuthRequestToken(function() {});
           assert.equal(oa.requestArguments[2], "GET");
         },
         'Use a POST by default': function(oa) {
+          oa.setClientOptions({});
           oa.getOAuthRequestToken(function() {});
+          assert.equal(oa.requestArguments[2], "POST");
+        }
+    },
+    'When getting an access token': {
+        topic: function() {
+          var oa= new OAuth(null, null, "consumerkey", "consumersecret", "1.0", null, "HMAC-SHA1");
+          oa._getTimestamp= function(){ return "1272399856"; }
+          oa._getNonce= function(){ return "ybHPeOEkAUJ3k2wJT9Xb43MjtSgTvKqp"; }
+          oa._performSecureRequest= function(){ return this.requestArguments = arguments; }
+          return oa;
+        },
+        'Use the HTTP method in the client options': function(oa) {
+          oa.setClientOptions({ accessTokenHttpMethod: "GET" });
+          oa.getOAuthAccessToken(function() {});
+          assert.equal(oa.requestArguments[2], "GET");
+        },
+        'Use a POST by default': function(oa) {
+          oa.setClientOptions({});
+          oa.getOAuthAccessToken(function() {});
           assert.equal(oa.requestArguments[2], "POST");
         }
     },


### PR DESCRIPTION
Hows this for a better fix to issue #58?  Admittedly the option merging could do with its own tests, but its at least somewhat covered by the request token tests. I guess those could be de-duplicated too, but I'm not hugely familiar with vowsjs, so I've left it for now.
