### PR TITLE
Allows posting content from file

### DIFF
--- a/lib/oauth.js
+++ b/lib/oauth.js
@@ -410,7 +410,15 @@ exports.OAuth.prototype._performSecureRequest= function( oauth_token, oauth_toke
     if( (method == "POST" || method =="PUT") && post_body != null && post_body != "" ) {
       if(useFile) {
         var rs = fs.createReadStream(post_body);
-        rs.pipe(request);
+        // pipe hang on large file
+        // using data event cure the problem
+        //rs.pipe(request);
+        rs.on('data', function(chunk) {
+            request.write(chunk);
+          });
+        rs.on('end', function() {
+            request.end();
+          });
       }else {
        request.write(post_body);
        request.end();


### PR DESCRIPTION
Hello,

we are using your library with great success. We need to be able to upload file using oauth authentication.

Here is a patch for doing that.

It essentially add a new function :

exports.OAuth.prototype.postFromFile= function(url, oauth_token, oauth_token_secret, fileName, post_content_type, callback) {  
  return this._putOrPost("POST", url, oauth_token, oauth_token_secret, fileName, post_content_type, callback, true);
}

and add one more parameter (fromFile) to _putOrPost and _performSecureRequest functions to interpret body_content parameter as content or file name.

This implementation has only be done for oauth1.

Please feel free to ask for any modifications helping integration in your repo.

Thanks for your lib.

Xavier
