### PR TITLE
Fix issue #64 - encoding of PLAINTEXT signature

### DIFF
--- a/lib/oauth.js
+++ b/lib/oauth.js
@@ -189,11 +189,11 @@ exports.OAuth.prototype._createSignature= function(signatureBase, tokenSecret) {
    if( tokenSecret === undefined ) var tokenSecret= "";
    else tokenSecret= this._encodeData( tokenSecret ); 
    // consumerSecret is already encoded
-   var key= this._consumerSecret + "&" + tokenSecret;
+   var key= this._encodeData(this._consumerSecret) + "&" + this._encodeData(tokenSecret);
 
    var hash= ""
    if( this._signatureMethod == "PLAINTEXT" ) {
-     hash= this._encodeData(key);
+     hash= key;
    }
    else {
        if( crypto.Hmac ) {


### PR DESCRIPTION
Changes the encoding for PLAINTEXT signatures to not double-encode the ampersand as specified here:
http://tools.ietf.org/html/rfc5849#section-3.4.4 and
http://tools.ietf.org/html/rfc5849#section-2.1
