### PR TITLE
don't send the request using https if the uri is http

### DIFF
--- a/lib/oauth2.js
+++ b/lib/oauth2.js
@@ -1,12 +1,13 @@
 var querystring= require('querystring'),
     crypto= require('crypto'),
     https= require('https'),
+    http= require('http'),
     URL= require('url'),
     OAuthUtils= require('./_utils');
 
 exports.OAuth2= function(clientId, clientSecret, baseSite, authorizePath, accessTokenPath) {
   this._clientId= clientId;
-  this._clientSecret= clientSecret; 
+  this._clientSecret= clientSecret;
   this._baseSite= baseSite;
   this._authorizeUrl= authorizePath || "/oauth/authorize";
   this._accessTokenUrl= accessTokenPath || "/oauth/access_token";
@@ -28,10 +29,15 @@ exports.OAuth2.prototype._getAccessTokenUrl= function() {
 
 exports.OAuth2.prototype._request= function(method, url, headers, post_body, access_token, callback) {
 
-  var creds = crypto.createCredentials({ });  
-  var parsedUrl= URL.parse( url, true );   
-  if( parsedUrl.protocol == "https:" && !parsedUrl.port ) parsedUrl.port= 443;
-  
+  var creds = crypto.createCredentials({ });
+  var parsedUrl= URL.parse( url, true );
+  if( parsedUrl.protocol == "https:" && !parsedUrl.port ) {
+    parsedUrl.port= 443;
+    http_library = https;
+  } else {
+    http_library = http;
+  }
+
   var realHeaders= {};
   if( headers ) {
     for(var key in headers) {
@@ -72,7 +78,7 @@ exports.OAuth2.prototype._request= function(method, url, headers, post_body, acc
     }
   }
 
-  request = https.request(options, function (response) {
+  request = http_library.request(options, function (response) {
     response.on("data", function (chunk) {
       result+= chunk
     });
@@ -94,7 +100,7 @@ exports.OAuth2.prototype._request= function(method, url, headers, post_body, acc
      request.write(post_body);
   }
   request.end();
-} 
+}
 
 
 exports.OAuth2.prototype.getAuthorizeUrl= function( params ) {
@@ -139,7 +145,7 @@ exports.OAuth2.prototype.getOAuthAccessToken= function(code, params, callback) {
       callback(null, access_token, refresh_token);
     }
   });
-} 
+}
 
 // Deprecated
 exports.OAuth2.prototype.getProtectedResource= function(url, access_token, callback) {


### PR DESCRIPTION
When using `getOAuthAccessToken` on an HTTP (as not HTTPS) request, the _request method uses the https library anyway, which breaks the call and raises an error on some servers (maybe all, I only tried with a rails api run on thin).

This fixes the problem by using the http or https library accordingly depending of the protocol used in the API.
