### PR TITLE
Allow Buffers to be passed as post body, essential when POSTing binary data and other long chunks of data.

### DIFF
--- a/lib/oauth.js
+++ b/lib/oauth.js
@@ -328,7 +328,7 @@ exports.OAuth.prototype._performSecureRequest= function( oauth_token, oauth_toke
     post_body= querystring.stringify(extra_params);
   }
 
-  headers["Content-length"]= post_body ? Buffer.byteLength(post_body) : 0;
+  headers["Content-length"]= post_body ? Buffer.isBuffer(post_body) ? post_body.length : Buffer.byteLength(post_body) : 0;
   headers["Content-Type"]= post_content_type;
    
   var path;


### PR DESCRIPTION
New way of calculating post_body length when a Buffer is passed instead of a String
