### PR TITLE
[ #Issue 75 ] Fixing Live Protocol 302 Resources

### DIFF
--- a/lib/oauth2.js
+++ b/lib/oauth2.js
@@ -64,7 +64,7 @@ exports.OAuth2.prototype._request= function(method, url, headers, post_body, acc
   function passBackControl( response, result ) {
     if(!callbackCalled) {
       callbackCalled=true;
-      if( response.statusCode != 200 ) {
+      if( response.statusCode != 200 && (response.statusCode != 301) && (response.statusCode != 302) ) {
         callback({ statusCode: response.statusCode, data: result });
       } else {
         callback(null, result, response);


### PR DESCRIPTION
Fixing a issue where Windows Live protocol return some resources as HTTP Header Location data.

For example, if i want to get the profile picture for MSN, the URL of resource is the Location of a HTTP header. So, if i dont want the data (the data of image), and URL for download or for display the image, we must have access to that info in response.

Fixed and requesting a Pull.
