### PR TITLE
Allow PATCH to send request body

### DIFF
--- a/apiary.apib
+++ b/apiary.apib
@@ -1,0 +1,83 @@
+-- Shopping Cart Resources --
+GET /shopping-cart
+< 200
+{ "items": [
+  { "url": "/shopping-cart/1", "product":"2ZY48XPZ", "quantity": 1, "name": "New socks", "price": 1.25 }
+] }
+
+
+Comment block for this resource (support [Markdown](http://daringfireball.net/projects/markdown/syntax) format syntax)
+POST /shopping-cart
+> Content-Type: application/json
+{ "product":"1AB23ORM", "quantity": 2 }
+< 201
+< Content-Type: application/json
+{ "status": "created", "url": "/shopping-cart/2" }
+
+
+-- Payment Resources --
+This resource allows you to submit payment information to process **your** *shopping cart* items
+Also important is to realize that the comments can be multi-line, including lists like this one:
+
+* Red
+* Green
+* Blue
+
+And headings like this one:
+
+# I am a cool heading!
+POST /payment
+{ cc: "12345678900", cvc: "123", expiry: "0112" }
+< 200
+{ receipt: "/payment/receipt/1" }
+
+-- JSON Schema Validations --
+POST /shopping-cart
+{
+  "type": "object",
+  "properties": {
+    "product": {
+      "type": "string",
+      "length": 8,
+      "format": "alphanumeric"
+    },
+    "quantity": {
+      "type": "number"
+    }
+  }
+}
+
+GET /shopping-cart-off
+{
+  "type": "object",
+  "properties": {
+    "items": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "properties": {
+          "url": {
+            "required": true,
+            "type": "string"
+          },
+          "product": {
+            "required": true,
+            "type": "string",
+            "length": 8,
+            "format": "alphanumeric"
+          },
+          "quantity": {
+            "type": "number"
+          },
+          "name": {
+            "required": true,
+            "type": "string"
+          },
+          "price": {
+            "type": "number"
+          }
+        }
+      }
+    }
+  }
+}

--- a/lib/oauth2.js
+++ b/lib/oauth2.js
@@ -90,7 +90,7 @@ exports.OAuth2.prototype._request= function(method, url, headers, post_body, acc
     callback(e);
   });
 
-  if(  method == 'POST' && post_body ) {
+  if( ( method == 'POST' || method == 'PATCH' ) && post_body ) {
      request.write(post_body);
   }
   request.end();

--- a/lib/oauth2.js
+++ b/lib/oauth2.js
@@ -89,10 +89,12 @@ exports.OAuth2.prototype._request= function(method, url, headers, post_body, acc
     callbackCalled= true;
     callback(e);
   });
-
+  console.error("Request almost created");
   if( ( method == 'POST' || method == 'PATCH' ) && post_body ) {
+     console.error("Adding method body");
      request.write(post_body);
   }
+  console.error("Request going to end");
   request.end();
 } 
 

--- a/lib/oauth2.js
+++ b/lib/oauth2.js
@@ -27,6 +27,7 @@ exports.OAuth2.prototype._getAccessTokenUrl= function() {
 }
 
 exports.OAuth2.prototype._request= function(method, url, headers, post_body, access_token, callback) {
+  console.error("Going to _request");
 
   var creds = crypto.createCredentials({ });  
   var parsedUrl= URL.parse( url, true );   
@@ -56,6 +57,7 @@ exports.OAuth2.prototype._request= function(method, url, headers, post_body, acc
     method: method,
     headers: realHeaders
   };
+  console.error("options created");
 
   // Some hosts *cough* google appear to close the connection early / send no content-length header
   // allow this behaviour.
@@ -72,6 +74,7 @@ exports.OAuth2.prototype._request= function(method, url, headers, post_body, acc
     }
   }
 
+  console.error("Creating real https request");
   var request = https.request(options, function (response) {
     response.on("data", function (chunk) {
       result+= chunk
@@ -85,6 +88,7 @@ exports.OAuth2.prototype._request= function(method, url, headers, post_body, acc
       passBackControl( response, result );
     });
   });
+  console.error("Is in our var");
   request.on('error', function(e) {
     callbackCalled= true;
     callback(e);

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 { "name" : "oauth"
 , "description" : "Library for interacting with OAuth 1.0, 1.0A, 2 and Echo.  Provides simplified client access and allows for construction of more complex apis and OAuth providers."
-, "version" : "0.9.5"
+, "version" : "0.9.6"
 , "directories" : { "lib" : "./lib" }
 , "main" : "index.js"
 , "author" : "Ciaran Jessup <ciaranj@gmail.com>"


### PR DESCRIPTION
Some resources use PATCH request to update given entity (i.e. github).

Attach post_body not only with POST, but with PATCH, too.
