### PR TITLE
Add support for refreshing an access token

### DIFF
--- a/lib/oauth2.js
+++ b/lib/oauth2.js
@@ -109,7 +109,8 @@ exports.OAuth2.prototype.getOAuthAccessToken= function(code, params, callback) {
   params['client_id'] = this._clientId;
   params['client_secret'] = this._clientSecret;
   params['type']= 'web_server';
-  params['code']= code;
+  var codeParam = (params.grant_type === 'refresh_token') ? 'refresh_token' : 'code';
+  params[codeParam]= code;
 
   var post_data= querystring.stringify( params );
   var post_headers= {


### PR DESCRIPTION
This adds support for refreshing an access token via oauth2.getOAuthAccessToken().  The first parameter sent to the method can either be a authorization code or a refresh token.  If among the parameters is grant_type and it is equal to 'refresh_token', then change the parameter name of the code to 'refresh_token' instead of 'code'.

http://tools.ietf.org/html/draft-ietf-oauth-v2-16#section-6

https://developers.google.com/accounts/docs/OAuth2InstalledApp#refresh
