### PR TITLE
"Authorization" header in OAuth 2.0 protocol

### DIFF
--- a/lib/oauth2.js
+++ b/lib/oauth2.js
@@ -44,6 +44,7 @@ exports.OAuth2.prototype._request= function(method, url, headers, post_body, acc
   if( access_token ) {
     if( ! parsedUrl.query ) parsedUrl.query= {};
     parsedUrl.query[this._accessTokenName]= access_token;
+    realHeaders['Authorization']="OAuth2 " + access_token;
   }
 
   var result= "";


### PR DESCRIPTION
Current version 0.9.6 Oauth2 does not implement "Authorization" header which is defined in OAuth 2.0 protocol. Although Facebook seems to be ignoring, other services do. 

Just one line addition, but works greatly with other such services. 
