### PR TITLE
Add a section in the Readme for installation instructions

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -7,6 +7,12 @@ Tested against Twitter (http://twitter.com), term.ie (http://term.ie/oauth/examp
 Also provides rudimentary OAuth2 support, tested against facebook, github, foursquare, google and Janrain.   For more complete usage examples please take a look at connect-auth (http://github.com/ciaranj/connect-auth)
 
 
+Installation
+============== 
+
+    $ npm install oauth
+
+
 Change History
 ============== 
 


### PR DESCRIPTION
There are number of oauth solutions for node.js and it is
helpful to provide the official installation instructions
in the Readme file.  Installation instructions can be a little
confusing for this module because the github repository name
is node-oauth and there is a different  node.js oauth
solution that isntalls via npm with the command node-oauth.
Since this solution installs with oauth official
instructions may be helpful to some developers.
