### PR TITLE
Oauth 1.0 - Authorization Headers

### DIFF
--- a/lib/oauth.js
+++ b/lib/oauth.js
@@ -30,6 +30,7 @@ exports.OAuth= function(requestUrl, accessUrl, consumerKey, consumerSecret, vers
                                    "User-Agent" : "Node authentication"}
   this._clientOptions= this._defaultClientOptions= {"requestTokenHttpMethod": "POST",
                                                     "accessTokenHttpMethod": "POST"};
+  this._oauthParameterSeperator = ",";
 };
 
 exports.OAuthEcho= function(realm, verify_credentials, consumerKey, consumerSecret, version, signatureMethod, nonceSize, customHeaders) {
@@ -48,6 +49,7 @@ exports.OAuthEcho= function(realm, verify_credentials, consumerKey, consumerSecr
   this._headers= customHeaders || {"Accept" : "*/*",
                                    "Connection" : "close",
                                    "User-Agent" : "Node authentication"};
+  this._oauthParameterSeperator = ",";
 }
 
 exports.OAuthEcho.prototype = exports.OAuth.prototype;
@@ -118,11 +120,11 @@ exports.OAuth.prototype._buildAuthorizationHeaders= function(orderedParameters) 
      // Whilst the all the parameters should be included within the signature, only the oauth_ arguments
      // should appear within the authorization header.
      if( this._isParameterNameAnOAuthParameter(orderedParameters[i][0]) ) {
-      authHeader+= "" + this._encodeData(orderedParameters[i][0])+"=\""+ this._encodeData(orderedParameters[i][1])+"\",";
+      authHeader+= "" + this._encodeData(orderedParameters[i][0])+"=\""+ this._encodeData(orderedParameters[i][1])+"\""+ this._oauthParameterSeperator;
      }
   }
 
-  authHeader= authHeader.substring(0, authHeader.length-1);
+  authHeader= authHeader.substring(0, authHeader.length-this._oauthParameterSeperator.length);  
   return authHeader;
 }
 


### PR DESCRIPTION
I just checked the (http://oauth.net/core/1.0/) documentation, section **5.4.1 Authorization Header**.

There, it says:

> Parameters are separated by a comma character (ASCII code 44) and OPTIONAL linear whitespace per [RFC2617].

Since the service I had to work with only accepted requests with whitespaces (", ") after the comma, I implemented a variable that allows you to define the seperator between the OAuth parameters:
### Usage

```
var oaclient = new OAuth(...);
oaclient._oauthParameterSeperator = ", ";
```
### Default

The default behavior **has not changed**:

```
_oauthParameterSeperator = ",";
```
