### PR TITLE
Adding support for HTTP(S) proxies

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -6,6 +6,8 @@ Tested against Twitter (http://twitter.com), term.ie (http://term.ie/oauth/examp
 
 Also provides rudimentary OAuth2 support, tested against facebook, github, foursquare, google and Janrain.   For more complete usage examples please take a look at connect-auth (http://github.com/ciaranj/connect-auth)
 
+Requests may use a HTTP or HTTPS proxy if desired. Set the environment variables `HTTP_PROXY_HOST` and `HTTP_PROXY_PORT` to proxy http traffic. Similarly `HTTPS_PROXY_HOST` and `HTTPS_PROXY_PORT` for https traffic.
+
 
 Installation
 ============== 

--- a/lib/oauth.js
+++ b/lib/oauth.js
@@ -232,6 +232,7 @@ exports.OAuth.prototype._createClient= function( port, hostname, method, path, h
     method: method,
     headers: headers
   };
+  this._proxyRequest(sslEnabled, options);
   var httpModel;
   if( sslEnabled ) {
     httpModel= https;
@@ -402,6 +403,47 @@ exports.OAuth.prototype._performSecureRequest= function( oauth_token, oauth_toke
   }
   
   return;
+}
+
+exports.OAuth.prototype._proxyRequest = function (secure, options) {
+  /* 
+  If process.env['HTTP_PROXY_HOST'] and the env variable `HTTP_PROXY_POST`
+  are set, make sure path and the header Host are set to target url.
+
+  Similarly, `HTTPS_PROXY_HOST` and `HTTPS_PROXY_PORT` can be used
+  to proxy HTTPS traffic.
+
+  Proxies Example:
+      export HTTP_PROXY_HOST=localhost
+      export HTTP_PROXY_PORT=8080
+      export HTTPS_PROXY_HOST=localhost
+      export HTTPS_PROXY_PORT=8442
+  */
+  var targetHost = options.host,
+      protocol = secure ? 'https:' : 'http:';
+  if (!targetHost) return;
+
+  var updateOptions = function (envPrefix) {
+    var proxyHostname = process.env[envPrefix + '_PROXY_HOST'].trim();
+    var proxyPort = parseInt(process.env[envPrefix + '_PROXY_PORT'], 10);
+    if (proxyHostname.length > 0 && ! isNaN(proxyPort)) {
+
+      if (! options.headers) options.headers = {};
+
+      options.host = proxyHostname;
+      options.port = proxyPort;
+      options.path = protocol + '//' + targetHost + options.path;
+      options.headers['Host'] = targetHost;
+    }
+  };
+  if ('https:' === protocol &&
+      !! process.env['HTTPS_PROXY_HOST'] &&
+      !! process.env['HTTPS_PROXY_PORT']) {
+    updateOptions('HTTPS');
+  } else if (!! process.env['HTTP_PROXY_HOST'] &&
+             !! process.env['HTTP_PROXY_PORT']) {
+    updateOptions('HTTP');
+  }
 }
 
 exports.OAuth.prototype.setClientOptions= function(options) {

--- a/lib/oauth2.js
+++ b/lib/oauth2.js
@@ -66,6 +66,8 @@ exports.OAuth2.prototype._request= function(method, url, headers, post_body, acc
     headers: realHeaders
   };
 
+  this._proxyRequest(parsedUrl.protocol, options);
+
   // Some hosts *cough* google appear to close the connection early / send no content-length header
   // allow this behaviour.
   var allowEarlyClose= OAuthUtils.isAnEarlyCloseHost(options.host);
@@ -103,6 +105,46 @@ exports.OAuth2.prototype._request= function(method, url, headers, post_body, acc
      request.write(post_body);
   }
   request.end();
+}
+
+exports.OAuth2.prototype._proxyRequest = function (protocol, options) {
+  /* 
+  If process.env['HTTP_PROXY_HOST'] and the env variable `HTTP_PROXY_POST`
+  are set, make sure path and the header Host are set to target url.
+
+  Similarly, `HTTPS_PROXY_HOST` and `HTTPS_PROXY_PORT` can be used
+  to proxy HTTPS traffic.
+
+  Proxies Example:
+      export HTTP_PROXY_HOST=localhost
+      export HTTP_PROXY_PORT=8080
+      export HTTPS_PROXY_HOST=localhost
+      export HTTPS_PROXY_PORT=8442
+  */
+  var targetHost = options.host;
+  if (!targetHost) return;
+
+  var updateOptions = function (envPrefix) {
+    var proxyHostname = process.env[envPrefix + '_PROXY_HOST'].trim();
+    var proxyPort = parseInt(process.env[envPrefix + '_PROXY_PORT'], 10);
+    if (proxyHostname.length > 0 && ! isNaN(proxyPort)) {
+
+      if (! options.headers) options.headers = {};
+
+      options.host = proxyHostname;
+      options.port = proxyPort;
+      options.path = protocol + '//' + targetHost + options.path;
+      options.headers['Host'] = targetHost;
+    }
+  };
+  if ('https:' === protocol &&
+      !! process.env['HTTPS_PROXY_HOST'] &&
+      !! process.env['HTTPS_PROXY_PORT']) {
+    updateOptions('HTTPS');
+  } else if (!! process.env['HTTP_PROXY_HOST'] &&
+             !! process.env['HTTP_PROXY_PORT']) {
+    updateOptions('HTTP');
+  }
 }
 
 


### PR DESCRIPTION
Adding support for the following env variables:
- HTTP_PROXY_HOST
- HTTP_PROXY_PORT
- HTTPS_PROXY_HOST
- HTTPS_PROXY_PORT

Compatible with node-openid.

Proposed fix for Issues #102.
