### PR TITLE
Allow setting extra_params in signUrl

### DIFF
--- a/lib/oauth.js
+++ b/lib/oauth.js
@@ -528,13 +528,17 @@ exports.OAuth.prototype.getOAuthRequestToken= function( extraParams, callback ) 
   });
 }
 
-exports.OAuth.prototype.signUrl= function(url, oauth_token, oauth_token_secret, method) {
+exports.OAuth.prototype.signUrl= function(url, oauth_token, oauth_token_secret, method, extra_params) {
 
   if( method === undefined ) {
     var method= "GET";
   }
 
-  var orderedParameters= this._prepareParameters(oauth_token, oauth_token_secret, method, url, {});
+  if( extra_params === undefined ) {
+    extra_params = {};
+  }
+
+  var orderedParameters= this._prepareParameters(oauth_token, oauth_token_secret, method, url, extra_params);
   var parsedUrl= URL.parse( url, false );
 
   var query=""; 
@@ -546,11 +550,15 @@ exports.OAuth.prototype.signUrl= function(url, oauth_token, oauth_token_secret, 
   return parsedUrl.protocol + "//"+ parsedUrl.host + parsedUrl.pathname + "?" + query;
 };
 
-exports.OAuth.prototype.authHeader= function(url, oauth_token, oauth_token_secret, method) {
+exports.OAuth.prototype.authHeader= function(url, oauth_token, oauth_token_secret, method, extra_params) {
   if( method === undefined ) {
     var method= "GET";
   }
 
-  var orderedParameters= this._prepareParameters(oauth_token, oauth_token_secret, method, url, {});
+  if( extra_params === undefined ) {
+    extra_params = {};
+  }
+
+  var orderedParameters= this._prepareParameters(oauth_token, oauth_token_secret, method, url, extra_params);
   return this._buildAuthorizationHeaders(orderedParameters);
 };


### PR DESCRIPTION
This doesn't change the existing functionality in any way, it simply allows setting extra_params when the user wants to. If the continues not to set it, the extra_params variable will simply be set to {} as before.

I need this for a flickr API library, because their upload call requires signing, but then reducing the signed parameters into form/multipart along with the file itself.
