### PR TITLE
Added `realm` to all calls if specified (not just echo)

### DIFF
--- a/lib/oauth.js
+++ b/lib/oauth.js
@@ -6,7 +6,7 @@ var crypto= require('crypto'),
     querystring= require('querystring'),
     OAuthUtils= require('./_utils');
 
-exports.OAuth= function(requestUrl, accessUrl, consumerKey, consumerSecret, version, authorize_callback, signatureMethod, nonceSize, customHeaders) {
+exports.OAuth= function(requestUrl, accessUrl, consumerKey, consumerSecret, version, authorize_callback, signatureMethod, nonceSize, customHeaders, realm) {
   this._isEcho = false;
 
   this._requestUrl= requestUrl;
@@ -28,6 +28,7 @@ exports.OAuth= function(requestUrl, accessUrl, consumerKey, consumerSecret, vers
   this._headers= customHeaders || {"Accept" : "*/*",
                                    "Connection" : "close",
                                    "User-Agent" : "Node authentication"}
+  this._realm= realm;
   this._clientOptions= this._defaultClientOptions= {"requestTokenHttpMethod": "POST",
                                                     "accessTokenHttpMethod": "POST"};
   this._oauthParameterSeperator = ",";
@@ -112,7 +113,7 @@ exports.OAuth.prototype._isParameterNameAnOAuthParameter= function(parameter) {
 // build the OAuth request authorization header
 exports.OAuth.prototype._buildAuthorizationHeaders= function(orderedParameters) {
   var authHeader="OAuth ";
-  if( this._isEcho ) {
+  if( this._realm ) {
     authHeader += 'realm="' + this._realm + '",';
   }
 

--- a/tests/oauth.js
+++ b/tests/oauth.js
@@ -267,6 +267,18 @@ vows.describe('OAuth').addBatch({
        Array.prototype.toString = _toString;
       }
     },
+    'When building the OAuth Authorization header with a realm': {
+      topic: new OAuth(null, null, null, null, null, null, "HMAC-SHA1", null, null, 'http://foobar.com/'), 
+      'The realm should be prepended correctly' : function(oa) {
+       var parameters= [
+          ["oauth_timestamp",         "1234567"],
+          ["oauth_nonce",             "ABCDEF"],
+          ["oauth_version",           "1.0"],
+          ["oauth_signature_method",  "HMAC-SHA1"],
+          ["oauth_consumer_key",      "asdasdnm2321b3"]];
+        assert.equal(oa._buildAuthorizationHeaders(parameters), 'OAuth realm="http://foobar.com/",oauth_timestamp="1234567",oauth_nonce="ABCDEF",oauth_version="1.0",oauth_signature_method="HMAC-SHA1",oauth_consumer_key="asdasdnm2321b3"'); 
+      }
+    },
     'When performing the Secure Request' : {
       topic: new OAuth("http://foo.com/RequestToken",
                        "http://foo.com/AccessToken",


### PR DESCRIPTION
- As per http://tools.ietf.org/html/rfc5849#section-3.5.1
- Some APIs require `realm` to be added to each call
