### PR TITLE
Fix requests containing !'()* in POST data

### DIFF
--- a/lib/oauth.js
+++ b/lib/oauth.js
@@ -327,7 +327,13 @@ exports.OAuth.prototype._performSecureRequest= function( oauth_token, oauth_toke
   }
 
   if( (method == "POST" || method == "PUT")  && ( post_body == null && extra_params != null) ) {
-    post_body= querystring.stringify(extra_params);
+    // Fix the mismatch between the output of querystring.stringify() and this._encodeData()
+    post_body= querystring.stringify(extra_params)
+                       .replace(/\!/g, "%21")
+                       .replace(/\'/g, "%27")
+                       .replace(/\(/g, "%28")
+                       .replace(/\)/g, "%29")
+                       .replace(/\*/g, "%2A");
   }
 
   headers["Content-length"]= post_body ? Buffer.byteLength(post_body) : 0;


### PR DESCRIPTION
This pull request fixes the mismatch between the output of `querystring.stringify()` and `this._encodeData()`, as discussed in https://github.com/ciaranj/node-oauth/issues/113.

Credits for NicolasPelletier for identifying the cause of this issue: https://github.com/ciaranj/node-oauth/issues/113#issuecomment-8956629
