### PR TITLE
Adding post_headers parameter to getOAuthAccessToken method.

### DIFF
--- a/lib/oauth2.js
+++ b/lib/oauth2.js
@@ -5,13 +5,15 @@ var querystring= require('querystring'),
     URL= require('url'),
     OAuthUtils= require('./_utils');
 
-exports.OAuth2= function(clientId, clientSecret, baseSite, authorizePath, accessTokenPath) {
+exports.OAuth2= function(clientId, clientSecret, baseSite, authorizePath, accessTokenPath, customHeaders) {
   this._clientId= clientId;
   this._clientSecret= clientSecret;
   this._baseSite= baseSite;
   this._authorizeUrl= authorizePath || "/oauth/authorize";
   this._accessTokenUrl= accessTokenPath || "/oauth/access_token";
   this._accessTokenName= "access_token";
+  this._authMethod= "Bearer";
+  this._customHeaders = customHeaders || {};
 }
 
 // This 'hack' method is required for sites that don't use
@@ -23,9 +25,21 @@ exports.OAuth2.prototype.setAccessTokenName= function ( name ) {
   this._accessTokenName= name;
 }
 
+// Sets the authorization method for Authorization header.
+// e.g. Authorization: Bearer <token>  # "Bearer" is the authorization method.
+exports.OAuth2.prototype.setAuthMethod = function ( authMethod ) {
+  this._authMethod = authMethod;
+};
+
 exports.OAuth2.prototype._getAccessTokenUrl= function() {
   return this._baseSite + this._accessTokenUrl; /* + "?" + querystring.stringify(params); */
 }
+
+// Build the authorization header. In particular, build the part after the colon.
+// e.g. Authorization: Bearer <token>  # Build "Bearer <token>"
+exports.OAuth2.prototype._buildAuthHeader= function(token) {
+  return this._authMethod + ' ' + token;
+};
 
 exports.OAuth2.prototype._request= function(method, url, headers, post_body, access_token, callback) {
 
@@ -41,7 +55,7 @@ exports.OAuth2.prototype._request= function(method, url, headers, post_body, acc
     http_library= http;
   }
 
-  var realHeaders= {};
+  var realHeaders= this._customHeaders;
   if( headers ) {
     for(var key in headers) {
       realHeaders[key] = headers[key];
@@ -157,5 +171,8 @@ exports.OAuth2.prototype.getProtectedResource= function(url, access_token, callb
 }
 
 exports.OAuth2.prototype.get= function(url, access_token, callback) {
-  this._request("GET", url, {}, "", access_token, callback );
+  var headers= {
+    'Authorization': this._buildAuthHeader(access_token)
+  };
+  this._request("GET", url, headers, "", access_token, callback );
 }

--- a/tests/oauth2.js
+++ b/tests/oauth2.js
@@ -1,10 +1,11 @@
 var vows = require('vows'),
     assert = require('assert'),
+    https = require('https'),
     OAuth2= require('../lib/oauth2').OAuth2;
 
 vows.describe('OAuth2').addBatch({
-    'Given an OAuth2 instance, ': {
-      topic: new OAuth2(),
+    'Given an OAuth2 instance with clientId and clientSecret, ': {
+      topic: new OAuth2("clientId", "clientSecret"),
       'When handling the access token response': {
         'we should correctly extract the token if received as form-data': function (oa) {
             oa._request= function( method, url, fo, bar, bleh, callback) {
@@ -40,27 +41,56 @@ vows.describe('OAuth2').addBatch({
       'When no grant_type parameter is specified': {
         'we should pass the value of the code argument as the code parameter': function(oa) {
           oa._request= function(method, url, headers, post_body, access_token, callback) {
-            assert.isTrue( post_body.indexOf("code=xsds23") != -1 )
-          }
+            assert.isTrue( post_body.indexOf("code=xsds23") != -1 );
+          };
           oa.getOAuthAccessToken("xsds23", {} );
         }
       },
       'When an invalid grant_type parameter is specified': {
         'we should pass the value of the code argument as the code parameter': function(oa) {
           oa._request= function(method, url, headers, post_body, access_token, callback) {
-            assert.isTrue( post_body.indexOf("code=xsds23") != -1 )
-          }
+            assert.isTrue( post_body.indexOf("code=xsds23") != -1 );
+          };
           oa.getOAuthAccessToken("xsds23", {grant_type:"refresh_toucan"} );
         }
       },
       'When a grant_type parameter of value "refresh_token" is specified': {
         'we should pass the value of the code argument as the refresh_token parameter, should pass a grant_type parameter, but shouldn\'t pass a code parameter' : function(oa) {
           oa._request= function(method, url, headers, post_body, access_token, callback) {
-            assert.isTrue( post_body.indexOf("refresh_token=sdsds2") != -1 )
-            assert.isTrue( post_body.indexOf("grant_type=refresh_token") != -1 )
-            assert.isTrue( post_body.indexOf("code=") == -1 )
-          }
+            assert.isTrue( post_body.indexOf("refresh_token=sdsds2") != -1 );
+            assert.isTrue( post_body.indexOf("grant_type=refresh_token") != -1 );
+            assert.isTrue( post_body.indexOf("code=") == -1 );
+          };
           oa.getOAuthAccessToken("sdsds2", {grant_type:"refresh_token"} );
+        }
+      },
+      'When calling get with the default authorization method': {
+        'we should pass the authorization header with Bearer method and value of the access_token' : function(oa) {
+          oa._request= function(method, url, headers, post_body, access_token, callback) {
+            assert.equal(headers["Authorization"], "Bearer abcd5");
+          };
+          oa.get("", "abcd5");
+        }
+      },
+      'When calling get with the authorization method set to Basic': {
+        'we should pass the authorization header with Basic method and value of the access_token' : function(oa) {
+          oa._request= function(method, url, headers, post_body, access_token, callback) {
+            assert.equal(headers["Authorization"], "Basic cdg2");
+          };
+          oa.setAuthMethod("Basic");
+          oa.get("", "cdg2");
+        }
+      }
+    },
+    'Given an OAuth2 instance with clientId, clientSecret and customHeaders': {
+      topic: new OAuth2("clientId", "clientSecret", undefined, undefined, undefined,
+          { 'SomeHeader': '123' }),
+      'When calling get': {
+        'we should see the custom headers mixed into headers property in options passed to http-library' : function(oa) {
+          https.request = function(options, callback) {
+            assert.equal(headers["SomeHeader"], "123");
+          };
+          oa.get("", {});
         }
       }
     }


### PR DESCRIPTION
Adding post_headers parameter to getOAuthAccessToken method. This would be useful, for example, for specifying bearer token in Authorization header (Stripe Connect is such a case).
