### PR TITLE
missing response.setEncoding('utf8')

### DIFF
--- a/lib/oauth2.js
+++ b/lib/oauth2.js
@@ -96,6 +96,7 @@ exports.OAuth2.prototype._request= function(method, url, headers, post_body, acc
   }
 
   var request = http_library.request(options, function (response) {
+    response.setEncoding('utf8');
     response.on("data", function (chunk) {
       result+= chunk
     });


### PR DESCRIPTION
I thought oauth2.js missed one line `response.setEncoding('utf8')`, the oauh.js has this line.

But missing the line, the `chunk` is a buffer, and `result+= chunk` will cause encoding problem. Because one char in utf8 (one char in may bytes) maybe separated into two buffers. and `result+=chunk` implies chunk convert to string first, so one good char becomes two broken char.

This is the same problem as issues #118, and I think pull request #80 is a good idea, but it should be applied to oauth2.js as well.
