### PR TITLE
Calculating the signature of foo=1&bar=false removes the value "false"

### DIFF
--- a/lib/oauth.js
+++ b/lib/oauth.js
@@ -59,7 +59,7 @@ exports.OAuth.prototype._getTimestamp= function() {
 }
 
 exports.OAuth.prototype._encodeData= function(toEncode){
- if( toEncode == null || toEncode == "" ) return ""
+ if( toEncode == null || toEncode === "" ) return ""
  else {
     var result= encodeURIComponent(toEncode);
     // Fix the mismatch between OAuth's  RFC3986's and Javascript's beliefs in what is right and wrong ;)


### PR DESCRIPTION
Since JS will equal "" == false, when the signature is calculated in oauth.js, a property with a value of false will get the parameters for the signature without the actual "false", since it was checked agains "". So to fix this we just need to test all properties with === instead of ==.
Otherwise, the signature check will fail if the server end calculates the signature correctly.
