### PR TITLE
Don't turn parameters like "?foo=bar&foo=baz" into "?foo[0]=bar&foo[1]=b...

### DIFF
--- a/lib/oauth.js
+++ b/lib/oauth.js
@@ -273,7 +273,7 @@ exports.OAuth.prototype._prepareParameters= function( oauth_token, oauth_token_s
       var extraParameters= querystring.parse(parsedUrl.query);
       for(var key in extraParameters ) {
         var value= extraParameters[key];
-          if( typeof value == "object" ){
+          if( typeof value == "object" && ! Array.isArray(value) ){
             // TODO: This probably should be recursive
             for(key2 in value){
               oauthParameters[key + "[" + key2 + "]"] = value[key2];

--- a/tests/oauth.js
+++ b/tests/oauth.js
@@ -118,11 +118,18 @@ vows.describe('OAuth').addBatch({
     'When preparing the parameters for use in signing': {
       topic: new OAuth(null, null, null, null, null, null, "HMAC-SHA1"),
       'We need to be wary of node\'s auto object creation from foo[bar] style url parameters' : function(oa) {
-        var result= oa._prepareParameters( "", "", "", "http://foo.com?foo[bar]=xxx&bar[foo]=yyy", {} );
+        var result= oa._prepareParameters( "", "", "", "http://foo.com?foo[bar]=xxx&bar[foo]=yyy&multi=a&multi=b", {} );
         assert.equal( result[0][0], "bar[foo]")
         assert.equal( result[0][1], "yyy")
         assert.equal( result[1][0], "foo[bar]")
         assert.equal( result[1][1], "xxx")
+      },
+      'Make sure multi-value parameters don\'t get turned into foo[bar] style url parameters' : function(oa) {
+        var result= oa._prepareParameters( "", "", "", "http://foo.com?foo=bar&foo=baz", {} );
+        assert.equal( result[0][0], "foo")
+        assert.equal( result[0][1], "bar")
+        assert.equal( result[1][0], "foo")
+        assert.equal( result[1][1], "baz")
       }
     },
     'When signing a url': {


### PR DESCRIPTION
This patch fixes a problem which causes multi-valued parameters to be turned into foo[0]=bar&foo[1]=baz style parameters.
