### PR TITLE
Client Authentication via Basic Authorization, not body

### DIFF
--- a/lib/oauth2.js
+++ b/lib/oauth2.js
@@ -129,8 +129,10 @@ exports.OAuth2.prototype.getAuthorizeUrl= function( params ) {
 
 exports.OAuth2.prototype.getOAuthAccessToken= function(code, params, callback) {
   var params= params || {};
-  params['client_id'] = this._clientId;
-  params['client_secret'] = this._clientSecret;
+  if (! 'Authorization' in this._customHeaders) {
+    params['client_id'] = this._clientId;
+    params['client_secret'] = this._clientSecret;
+  }
   params['type']= 'web_server';
   var codeParam = (params.grant_type === 'refresh_token') ? 'refresh_token' : 'code';
   params[codeParam]= code;


### PR DESCRIPTION
Hello.

The basic authorization is necessary to be supported when  we do a client authentication.
It is written [this rfc 2.3.1 Client password](http://tools.ietf.org/html/draft-ietf-oauth-v2-23).

Some OAuth2.0 implementation doesn't allow to include a client ID and client secret in the both of the body and the Authorization header.
So, I did this pull request.
