### PR TITLE
Support binary response bodies in _performSecureRequest

### DIFF
--- a/lib/oauth.js
+++ b/lib/oauth.js
@@ -378,7 +378,7 @@ exports.OAuth.prototype._performSecureRequest= function( oauth_token, oauth_toke
     }
 
     request.on('response', function (response) {
-      if (self._binaryContentType( response )) {
+      if (self._clientOptions.detectResponseContentType && self._binaryContentType( response )) {
           data= new Buffer( 0 );
           response.on('data', function (chunk) {
               data= Buffer.concat( [ data, chunk ] );


### PR DESCRIPTION
Change the response handling in _performSecureRequest so it can handle
binary data types in the response body. If it detects a response with
a content-type that looks binary (by default, image/_, audio/_, and
video/\* types), it stores the body in a Buffer rather than an UTF-8
string.

Closes #133.
