### PR TITLE
return the request object to reuse it later

### DIFF
--- a/lib/oauth.js
+++ b/lib/oauth.js
@@ -368,7 +368,8 @@ exports.OAuth.prototype._performSecureRequest= function( oauth_token, oauth_toke
         } else {
           // Follow 301 or 302 redirects with Location HTTP header
           if((response.statusCode == 301 || response.statusCode == 302) && response.headers && response.headers.location) {
-            self._performSecureRequest( oauth_token, oauth_token_secret, method, response.headers.location, extra_params, post_body, post_content_type,  callback);
+            var newRequest = self._performSecureRequest( oauth_token, oauth_token_secret, method, response.headers.location, extra_params, post_body, post_content_type,  callback);
+            request.emit('redirect', newRequest);
           }
           else {
             callback({ statusCode: response.statusCode, data: data }, data, response);


### PR DESCRIPTION
Currently only PUT/POST requests will return the request object.
Reuse the request object later may be operations like setTimeout, bind more event callbacks, etc.
Thanks!
