### PR TITLE
Enforce a User-Agent

### DIFF
--- a/lib/oauth2.js
+++ b/lib/oauth2.js
@@ -74,6 +74,8 @@ exports.OAuth2.prototype._request= function(method, url, headers, post_body, acc
   }
   realHeaders['Host']= parsedUrl.host;
 
+  realHeaders['User-Agent']= 'Node-oauth';
+
   realHeaders['Content-Length']= post_body ? Buffer.byteLength(post_body) : 0;
   if( access_token && !('Authorization' in realHeaders)) {
     if( ! parsedUrl.query ) parsedUrl.query= {};


### PR DESCRIPTION
To comply with at least Github (http://developer.github.com/v3/#user-agent-required), a supplied User-Agent is required. 
