### PR TITLE
Set default User-Agent if not otherwise specified in customHeaders

### DIFF
--- a/lib/oauth2.js
+++ b/lib/oauth2.js
@@ -74,6 +74,10 @@ exports.OAuth2.prototype._request= function(method, url, headers, post_body, acc
   }
   realHeaders['Host']= parsedUrl.host;
 
+  if (!realHeaders['User-Agent']) {
+    realHeaders['User-Agent'] = 'Node-oauth';
+  }
+
   realHeaders['Content-Length']= post_body ? Buffer.byteLength(post_body) : 0;
   if( access_token && !('Authorization' in realHeaders)) {
     if( ! parsedUrl.query ) parsedUrl.query= {};

--- a/tests/oauth2.js
+++ b/tests/oauth2.js
@@ -133,5 +133,29 @@ vows.describe('OAuth2').addBatch({
           oa.get("", {});
         }
       }
+    },
+    'When the user passes in the User-Agent in customHeaders': {
+      topic: new OAuth2("clientId", "clientSecret", undefined, undefined, undefined,
+          { 'User-Agent': '123Agent' }),
+      'When calling get': {
+        'we should see the User-Agent mixed into headers property in options passed to http-library' : function(oa) {
+          oa._executeRequest= function( http_library, options, callback ) {
+            assert.equal(options.headers["User-Agent"], "123Agent");
+          };
+          oa.get("", {});
+        }
+      }
+    },
+    'When the user does not pass in a User-Agent in customHeaders': {
+      topic: new OAuth2("clientId", "clientSecret", undefined, undefined, undefined,
+        undefined),
+      'When calling get': {
+        'we should see the default User-Agent mixed into headers property in options passed to http-library' : function(oa) {
+          oa._executeRequest= function( http_library, options, callback ) {
+            assert.equal(options.headers["User-Agent"], "Node-oauth");
+            };
+          oa.get("", {});
+        }
+      }
     }
 }).export(module);


### PR DESCRIPTION
Here's a more complete patch (with tests as requested) for https://github.com/ciaranj/node-oauth/pull/139

If no User-Agent has already been passed in to via customHeaders, the default User-Agent will be set as 'Node-oauth'.  

This should satisfy GitHub's recent change (http://developer.github.com/v3/#user-agent-required) which requires a User-Agent.
