### PR TITLE
(error, data, response) -> (error, response, data)

### DIFF
--- a/lib/oauth.js
+++ b/lib/oauth.js
@@ -364,14 +364,14 @@ exports.OAuth.prototype._performSecureRequest= function( oauth_token, oauth_toke
       if(!callbackCalled) {
         callbackCalled= true;
         if ( response.statusCode >= 200 && response.statusCode <= 299 ) {
-          callback(null, data, response);
+          callback(null, response, data);
         } else {
           // Follow 301 or 302 redirects with Location HTTP header
           if((response.statusCode == 301 || response.statusCode == 302) && response.headers && response.headers.location) {
             self._performSecureRequest( oauth_token, oauth_token_secret, method, response.headers.location, extra_params, post_body, post_content_type,  callback);
           }
           else {
-            callback({ statusCode: response.statusCode, data: data }, data, response);
+            callback({ statusCode: response.statusCode, data: data }, response, data);
           }
         }
       }
@@ -436,7 +436,7 @@ exports.OAuth.prototype.getOAuthAccessToken= function(oauth_token, oauth_token_s
     extraParams.oauth_verifier= oauth_verifier;
   }
   
-   this._performSecureRequest( oauth_token, oauth_token_secret, this._clientOptions.accessTokenHttpMethod, this._accessUrl, extraParams, null, null, function(error, data, response) {
+   this._performSecureRequest( oauth_token, oauth_token_secret, this._clientOptions.accessTokenHttpMethod, this._accessUrl, extraParams, null, null, function(error, response, data) {
          if( error ) callback(error);
          else {
            var results= querystring.parse( data );
@@ -514,7 +514,7 @@ exports.OAuth.prototype.getOAuthRequestToken= function( extraParams, callback ) 
   if( this._authorize_callback ) {
     extraParams["oauth_callback"]= this._authorize_callback;
   }
-  this._performSecureRequest( null, null, this._clientOptions.requestTokenHttpMethod, this._requestUrl, extraParams, null, null, function(error, data, response) {
+  this._performSecureRequest( null, null, this._clientOptions.requestTokenHttpMethod, this._requestUrl, extraParams, null, null, function(error, response, data) {
     if( error ) callback(error);
     else {
       var results= querystring.parse(data);


### PR DESCRIPTION
The popular node-request module is used just like like node-oauth, having get(), post(), put(), delete() methods.

But node-request's callback looks like this:

```
function(error, response, data){}
```

While node-oauth uses:

```
function(error, data, response){}
```

It's useful to switch simply from using node-request to node-oauth by replacing the dependency, so let's have the callback signatures conform so we can all keep it straight in our heads.
