### PR TITLE
Allow passing binary data to PUT or POST as a Buffer

### DIFF
--- a/lib/oauth.js
+++ b/lib/oauth.js
@@ -336,9 +336,18 @@ exports.OAuth.prototype._performSecureRequest= function( oauth_token, oauth_toke
                        .replace(/\*/g, "%2A");
   }
 
-  headers["Content-length"]= post_body ? Buffer.byteLength(post_body) : 0;
+  if( post_body ) {
+      if ( Buffer.isBuffer(post_body) ) {
+          headers["Content-length"]= post_body.length;
+      } else {
+          headers["Content-length"]= Buffer.byteLength(post_body);
+      }
+  } else {
+      headers["Content-length"]= 0;
+  }
+
   headers["Content-Type"]= post_content_type;
-   
+
   var path;
   if( !parsedUrl.pathname  || parsedUrl.pathname == "" ) parsedUrl.pathname ="/";
   if( parsedUrl.query ) path= parsedUrl.pathname + "?"+ parsedUrl.query ;
@@ -468,7 +477,7 @@ exports.OAuth.prototype._putOrPost= function(method, url, oauth_token, oauth_tok
     callback= post_content_type;
     post_content_type= null;
   }
-  if( typeof post_body != "string" ) {
+  if ( typeof post_body != "string" && !Buffer.isBuffer(post_body) ) {
     post_content_type= "application/x-www-form-urlencoded"
     extra_params= post_body;
     post_body= null;


### PR DESCRIPTION
Allow the post_body argument to a PUT or POST to be a Buffer. This will
pass the data directly to the request in binary form.

Closes #144.
