### PR TITLE
Add custom header controls for setting post construction

### DIFF
--- a/lib/oauth.js
+++ b/lib/oauth.js
@@ -86,7 +86,7 @@ exports.OAuth.prototype._getSignature= function(method, url, parameters, tokenSe
 exports.OAuth.prototype._normalizeUrl= function(url) {
   var parsedUrl= URL.parse(url, true)
    var port ="";
-   if( parsedUrl.port ) { 
+   if( parsedUrl.port ) {
      if( (parsedUrl.protocol == "http:" && parsedUrl.port != "80" ) ||
          (parsedUrl.protocol == "https:" && parsedUrl.port != "443") ) {
            port= ":" + parsedUrl.port;
@@ -94,7 +94,7 @@ exports.OAuth.prototype._normalizeUrl= function(url) {
    }
 
   if( !parsedUrl.pathname  || parsedUrl.pathname == "" ) parsedUrl.pathname ="/";
-   
+
   return parsedUrl.protocol + "//" + parsedUrl.hostname + port + parsedUrl.pathname;
 }
 
@@ -124,7 +124,7 @@ exports.OAuth.prototype._buildAuthorizationHeaders= function(orderedParameters) 
      }
   }
 
-  authHeader= authHeader.substring(0, authHeader.length-this._oauthParameterSeperator.length);  
+  authHeader= authHeader.substring(0, authHeader.length-this._oauthParameterSeperator.length);
   return authHeader;
 }
 
@@ -143,17 +143,17 @@ exports.OAuth.prototype._makeArrayOfArgumentsHash= function(argumentsHash) {
          argument_pairs[argument_pairs.length]= [key, value];
        }
   }
-  return argument_pairs;  
-} 
+  return argument_pairs;
+}
 
 // Sorts the encoded key value pairs by encoded name, then encoded value
 exports.OAuth.prototype._sortRequestParams= function(argument_pairs) {
   // Sort by name, then value.
   argument_pairs.sort(function(a,b) {
       if ( a[0]== b[0] )  {
-        return a[1] < b[1] ? -1 : 1; 
+        return a[1] < b[1] ? -1 : 1;
       }
-      else return a[0] < b[0] ? -1 : 1;  
+      else return a[0] < b[0] ? -1 : 1;
   });
 
   return argument_pairs;
@@ -166,10 +166,10 @@ exports.OAuth.prototype._normaliseRequestParams= function(arguments) {
     argument_pairs[i][0]= this._encodeData( argument_pairs[i][0] );
     argument_pairs[i][1]= this._encodeData( argument_pairs[i][1] );
   }
-  
+
   // Then sort them #3.4.1.3.2 .2
   argument_pairs= this._sortRequestParams( argument_pairs );
-  
+
   // Then concatenate together #3.4.1.3.2 .3 & .4
   var args= "";
   for(var i=0;i<argument_pairs.length;i++) {
@@ -177,19 +177,19 @@ exports.OAuth.prototype._normaliseRequestParams= function(arguments) {
       args+= "="
       args+= argument_pairs[i][1];
       if( i < argument_pairs.length-1 ) args+= "&";
-  }     
+  }
   return args;
 }
 
 exports.OAuth.prototype._createSignatureBase= function(method, url, parameters) {
-  url= this._encodeData( this._normalizeUrl(url) ); 
+  url= this._encodeData( this._normalizeUrl(url) );
   parameters= this._encodeData( parameters );
   return method.toUpperCase() + "&" + url + "&" + parameters;
 }
 
 exports.OAuth.prototype._createSignature= function(signatureBase, tokenSecret) {
    if( tokenSecret === undefined ) var tokenSecret= "";
-   else tokenSecret= this._encodeData( tokenSecret ); 
+   else tokenSecret= this._encodeData( tokenSecret );
    // consumerSecret is already encoded
    var key= this._consumerSecret + "&" + tokenSecret;
 
@@ -202,7 +202,7 @@ exports.OAuth.prototype._createSignature= function(signatureBase, tokenSecret) {
          hash = crypto.createHmac("sha1", key).update(signatureBase).digest("base64");
        }
        else {
-         hash= sha1.HMACSHA1(key, signatureBase);  
+         hash= sha1.HMACSHA1(key, signatureBase);
        }
    }
    return hash;
@@ -218,7 +218,7 @@ exports.OAuth.prototype._getNonce= function(nonceSize) {
    var chars= this.NONCE_CHARS;
    var char_pos;
    var nonce_chars_length= chars.length;
-   
+
    for (var i = 0; i < nonceSize; i++) {
        char_pos= Math.floor(Math.random() * nonce_chars_length);
        result[i]=  chars[char_pos];
@@ -240,7 +240,7 @@ exports.OAuth.prototype._createClient= function( port, hostname, method, path, h
   } else {
     httpModel= http;
   }
-  return httpModel.request(options);     
+  return httpModel.request(options);
 }
 
 exports.OAuth.prototype._prepareParameters= function( oauth_token, oauth_token_secret, method, url, extra_params ) {
@@ -338,7 +338,7 @@ exports.OAuth.prototype._performSecureRequest= function( oauth_token, oauth_toke
 
   headers["Content-length"]= post_body ? Buffer.byteLength(post_body) : 0;
   headers["Content-Type"]= post_content_type;
-   
+
   var path;
   if( !parsedUrl.pathname  || parsedUrl.pathname == "" ) parsedUrl.pathname ="/";
   if( parsedUrl.query ) path= parsedUrl.pathname + "?"+ parsedUrl.query ;
@@ -353,7 +353,7 @@ exports.OAuth.prototype._performSecureRequest= function( oauth_token, oauth_toke
   }
 
   if( callback ) {
-    var data=""; 
+    var data="";
     var self= this;
 
     // Some hosts *cough* google appear to close the connection early / send no content-length header
@@ -391,12 +391,12 @@ exports.OAuth.prototype._performSecureRequest= function( oauth_token, oauth_toke
         }
       });
     });
-  
+
     request.on("error", function(err) {
       callbackCalled= true;
       callback( err )
     });
-    
+
     if( (method == "POST" || method =="PUT") && post_body != null && post_body != "" ) {
       request.write(post_body);
     }
@@ -408,7 +408,7 @@ exports.OAuth.prototype._performSecureRequest= function( oauth_token, oauth_toke
     }
     return request;
   }
-  
+
   return;
 }
 
@@ -435,7 +435,7 @@ exports.OAuth.prototype.getOAuthAccessToken= function(oauth_token, oauth_token_s
   } else {
     extraParams.oauth_verifier= oauth_verifier;
   }
-  
+
    this._performSecureRequest( oauth_token, oauth_token_secret, this._clientOptions.accessTokenHttpMethod, this._accessUrl, extraParams, null, null, function(error, data, response) {
          if( error ) callback(error);
          else {
@@ -475,7 +475,7 @@ exports.OAuth.prototype._putOrPost= function(method, url, oauth_token, oauth_tok
   }
   return this._performSecureRequest( oauth_token, oauth_token_secret, method, url, extra_params, post_body, post_content_type, callback );
 }
- 
+
 
 exports.OAuth.prototype.put= function(url, oauth_token, oauth_token_secret, post_body, post_content_type, callback) {
   return this._putOrPost("PUT", url, oauth_token, oauth_token_secret, post_body, post_content_type, callback);
@@ -491,7 +491,7 @@ exports.OAuth.prototype.post= function(url, oauth_token, oauth_token_secret, pos
  *
  * The callback should expect a function of the following form:
  *
- * function(err, token, token_secret, parsedQueryString) {} 
+ * function(err, token, token_secret, parsedQueryString) {}
  *
  * This method has optional parameters so can be called in the following 2 ways:
  *
@@ -510,7 +510,7 @@ exports.OAuth.prototype.getOAuthRequestToken= function( extraParams, callback ) 
      callback = extraParams;
      extraParams = {};
    }
-  // Callbacks are 1.0A related 
+  // Callbacks are 1.0A related
   if( this._authorize_callback ) {
     extraParams["oauth_callback"]= this._authorize_callback;
   }
@@ -537,12 +537,12 @@ exports.OAuth.prototype.signUrl= function(url, oauth_token, oauth_token_secret, 
   var orderedParameters= this._prepareParameters(oauth_token, oauth_token_secret, method, url, {});
   var parsedUrl= URL.parse( url, false );
 
-  var query=""; 
+  var query="";
   for( var i= 0 ; i < orderedParameters.length; i++) {
     query+= orderedParameters[i][0]+"="+ this._encodeData(orderedParameters[i][1]) + "&";
   }
   query= query.substring(0, query.length-1);
- 
+
   return parsedUrl.protocol + "//"+ parsedUrl.host + parsedUrl.pathname + "?" + query;
 };
 
@@ -553,4 +553,12 @@ exports.OAuth.prototype.authHeader= function(url, oauth_token, oauth_token_secre
 
   var orderedParameters= this._prepareParameters(oauth_token, oauth_token_secret, method, url, {});
   return this._buildAuthorizationHeaders(orderedParameters);
+};
+
+exports.OAuth.prototype.setCustomHeader= function(header, value) {
+  this._headers[header] = value;
+};
+
+exports.OAuth.prototype.removeCustomHeader= function(header) {
+  return delete this._headers[header];
 };

--- a/tests/oauth.js
+++ b/tests/oauth.js
@@ -21,13 +21,13 @@ DummyRequest.prototype.write= function(post_body){
 }
 DummyRequest.prototype.end= function(){
   this.response.emit('end');
-}    
+}
 
 vows.describe('OAuth').addBatch({
     'When generating the signature base string described in http://oauth.net/core/1.0/#sig_base_example': {
         topic: new OAuth(null, null, null, null, null, null, "HMAC-SHA1"),
         'we get the expected result string': function (oa) {
-          var result= oa._createSignatureBase("GET", "http://photos.example.net/photos", 
+          var result= oa._createSignatureBase("GET", "http://photos.example.net/photos",
                                               "file=vacation.jpg&oauth_consumer_key=dpf43f3p2l4k3l03&oauth_nonce=kllo9940pd9333jh&oauth_signature_method=HMAC-SHA1&oauth_timestamp=1191242096&oauth_token=nnch734d00sl2jdk&oauth_version=1.0&size=original")
           assert.equal( result, "GET&http%3A%2F%2Fphotos.example.net%2Fphotos&file%3Dvacation.jpg%26oauth_consumer_key%3Ddpf43f3p2l4k3l03%26oauth_nonce%3Dkllo9940pd9333jh%26oauth_signature_method%3DHMAC-SHA1%26oauth_timestamp%3D1191242096%26oauth_token%3Dnnch734d00sl2jdk%26oauth_version%3D1.0%26size%3Doriginal");
         }
@@ -35,7 +35,7 @@ vows.describe('OAuth').addBatch({
     'When generating the signature base string with PLAINTEXT': {
         topic: new OAuth(null, null, null, null, null, null, "PLAINTEXT"),
         'we get the expected result string': function (oa) {
-          var result= oa._getSignature("GET", "http://photos.example.net/photos", 
+          var result= oa._getSignature("GET", "http://photos.example.net/photos",
                                               "file=vacation.jpg&oauth_consumer_key=dpf43f3p2l4k3l03&oauth_nonce=kllo9940pd9333jh&oauth_signature_method=PLAINTEXT&oauth_timestamp=1191242096&oauth_token=nnch734d00sl2jdk&oauth_version=1.0&size=original",
                                               "test");
           assert.equal( result, "&test");
@@ -58,7 +58,7 @@ vows.describe('OAuth').addBatch({
       topic: new OAuth(null, null, null, null, null, null, "HMAC-SHA1"),
       'flatten out arguments that are arrays' : function(oa) {
         var parameters= {"z": "a",
-                      "a": ["1", "2"], 
+                      "a": ["1", "2"],
                       "1": "c" };
         var parameterResults= oa._makeArrayOfArgumentsHash(parameters);
         assert.equal(parameterResults.length, 4);
@@ -72,30 +72,30 @@ vows.describe('OAuth').addBatch({
       topic: new OAuth(null, null, null, null, null, null, "HMAC-SHA1"),
       'Order them by name' : function(oa) {
         var parameters= {"z": "a",
-                      "a": "b", 
+                      "a": "b",
                       "1": "c" };
         var parameterResults= oa._sortRequestParams(oa._makeArrayOfArgumentsHash(parameters))
         assert.equal(parameterResults[0][0], "1");
-        assert.equal(parameterResults[1][0], "a");        
-        assert.equal(parameterResults[2][0], "z");        
+        assert.equal(parameterResults[1][0], "a");
+        assert.equal(parameterResults[2][0], "z");
       },
       'If two parameter names are the same then order by the value': function(oa) {
         var parameters= {"z": "a",
-                      "a": ["z", "b", "b", "a", "y"], 
+                      "a": ["z", "b", "b", "a", "y"],
                       "1": "c" };
         var parameterResults= oa._sortRequestParams(oa._makeArrayOfArgumentsHash(parameters))
         assert.equal(parameterResults[0][0], "1");
-        assert.equal(parameterResults[1][0], "a");        
-        assert.equal(parameterResults[1][1], "a");        
-        assert.equal(parameterResults[2][0], "a");        
-        assert.equal(parameterResults[2][1], "b");        
-        assert.equal(parameterResults[3][0], "a");        
-        assert.equal(parameterResults[3][1], "b");        
-        assert.equal(parameterResults[4][0], "a");        
-        assert.equal(parameterResults[4][1], "y");        
-        assert.equal(parameterResults[5][0], "a");        
-        assert.equal(parameterResults[5][1], "z");        
-        assert.equal(parameterResults[6][0], "z");        
+        assert.equal(parameterResults[1][0], "a");
+        assert.equal(parameterResults[1][1], "a");
+        assert.equal(parameterResults[2][0], "a");
+        assert.equal(parameterResults[2][1], "b");
+        assert.equal(parameterResults[3][0], "a");
+        assert.equal(parameterResults[3][1], "b");
+        assert.equal(parameterResults[4][0], "a");
+        assert.equal(parameterResults[4][1], "y");
+        assert.equal(parameterResults[5][0], "a");
+        assert.equal(parameterResults[5][1], "z");
+        assert.equal(parameterResults[6][0], "z");
       }
     },
     'When normalising the request parameters': {
@@ -193,7 +193,7 @@ vows.describe('OAuth').addBatch({
         'Support variable whitespace separating the arguments': function(oa) {
             oa._oauthParameterSeperator= ", ";
             assert.equal( oa.authHeader("http://somehost.com:3323/foo/poop?bar=foo", "token", "tokensecret"), 'OAuth oauth_consumer_key="consumerkey", oauth_nonce="ybHPeOEkAUJ3k2wJT9Xb43MjtSgTvKqp", oauth_signature_method="HMAC-SHA1", oauth_timestamp="1272399856", oauth_token="token", oauth_version="1.0", oauth_signature="zeOR0Wsm6EG6XSg0Vw%2FsbpoSib8%3D"');
-        }        
+        }
     },
     'When get the OAuth Echo authorization header': {
       topic: function () {
@@ -229,7 +229,7 @@ vows.describe('OAuth').addBatch({
         }
     },
     'When building the OAuth Authorization header': {
-      topic: new OAuth(null, null, null, null, null, null, "HMAC-SHA1"), 
+      topic: new OAuth(null, null, null, null, null, null, "HMAC-SHA1"),
       'All provided oauth arguments should be concatentated correctly' : function(oa) {
        var parameters= [
           ["oauth_timestamp",         "1234567"],
@@ -237,7 +237,7 @@ vows.describe('OAuth').addBatch({
           ["oauth_version",           "1.0"],
           ["oauth_signature_method",  "HMAC-SHA1"],
           ["oauth_consumer_key",      "asdasdnm2321b3"]];
-        assert.equal(oa._buildAuthorizationHeaders(parameters), 'OAuth oauth_timestamp="1234567",oauth_nonce="ABCDEF",oauth_version="1.0",oauth_signature_method="HMAC-SHA1",oauth_consumer_key="asdasdnm2321b3"'); 
+        assert.equal(oa._buildAuthorizationHeaders(parameters), 'OAuth oauth_timestamp="1234567",oauth_nonce="ABCDEF",oauth_version="1.0",oauth_signature_method="HMAC-SHA1",oauth_consumer_key="asdasdnm2321b3"');
       },
       '*Only* Oauth arguments should be concatentated, others should be disregarded' : function(oa) {
        var parameters= [
@@ -249,7 +249,7 @@ vows.describe('OAuth').addBatch({
           ["oauth_signature_method",  "HMAC-SHA1"],
           ["oauth_consumer_key",      "asdasdnm2321b3"],
           ["foobar",      "asdasdnm2321b3"]];
-        assert.equal(oa._buildAuthorizationHeaders(parameters), 'OAuth oauth_timestamp="1234567",oauth_nonce="ABCDEF",oauth_version="1.0",oauth_signature_method="HMAC-SHA1",oauth_consumer_key="asdasdnm2321b3"'); 
+        assert.equal(oa._buildAuthorizationHeaders(parameters), 'OAuth oauth_timestamp="1234567",oauth_nonce="ABCDEF",oauth_version="1.0",oauth_signature_method="HMAC-SHA1",oauth_consumer_key="asdasdnm2321b3"');
       },
       '_buildAuthorizationHeaders should not depends on Array.prototype.toString' : function(oa) {
        var _toString = Array.prototype.toString;
@@ -363,7 +363,7 @@ vows.describe('OAuth').addBatch({
              var testStringLength= testString.length;
              var testStringBytesLength= Buffer.byteLength(testString);
              assert.notEqual(testStringLength, testStringBytesLength); // Make sure we're testing a string that differs between byte-length and char-length!
-             
+
              var op= oa._createClient;
              try {
                var callbackCalled= false;
@@ -416,7 +416,7 @@ vows.describe('OAuth').addBatch({
            "and a post_content_type is specified" : {
              "It should be written as is, with a content length specified, and the encoding should be set to be as specified" : function(oa) {
                var op= oa._createClient;
-               try { 
+               try {
                  var callbackCalled= false;
                  oa._createClient= function( port, hostname, method, path, headers, sshEnabled ) {
                    assert.equal(headers["Content-Type"], "unicorn/encoded");
@@ -445,7 +445,7 @@ vows.describe('OAuth').addBatch({
          'if no callback is passed' : {
            'it should return a request object': function(oa) {
              var request= oa.get("http://foo.com/blah", "token", "token_secret")
-             assert.isObject(request); 
+             assert.isObject(request);
              assert.equal(request.method, "GET");
              request.end();
            }
@@ -466,6 +466,42 @@ vows.describe('OAuth').addBatch({
                var request= oa.get("http://foo.com/blah", "token", "token_secret", function(e,d) {})
                assert.equal(callbackCalled, true);
                assert.isUndefined(request);
+             }
+             finally {
+               oa._createClient= op;
+             }
+           }
+         },
+         'if using custom headers': {
+           'it should have the header set': function (oa) {
+             var op= oa._createClient;
+             oa.setCustomHeader('Accept-Language', 'en_GB');
+             try {
+               oa._createClient= function( port, hostname, method, path, headers, sshEnabled ) {
+                 assert.equal(headers["Accept-Language"], "en_GB");
+                 return { on: function() {}, end: function() {}};
+               };
+               var request= oa.get("http://foo.com/blah", "token", "token_secret", function(e,d) {})
+             }
+             finally {
+               oa._createClient= op;
+             }
+           },
+           'it should have the header removed': function (oa) {
+             var op= oa._createClient;
+             oa.setCustomHeader('Accept-Language', 'en_GB');
+             try {
+               oa._createClient= function( port, hostname, method, path, headers, sshEnabled ) {
+                 assert.equal(headers["Accept-Language"], "en_GB");
+                 return { on: function() {}, end: function() {}};
+               };
+               var request= oa.get("http://foo.com/blah", "token", "token_secret", function(e,d) {})
+               assert.isTrue(oa.removeCustomHeader('Accept-Language'));
+               oa._createClient= function( port, hostname, method, path, headers, sshEnabled ) {
+                 assert.equal(headers["Accept-Language"], void 0);
+                 return { on: function() {}, end: function() {}};
+               };
+               request= oa.get("http://foo.com/blah", "token", "token_secret", function(e,d) {})
              }
              finally {
                oa._createClient= op;
@@ -556,11 +592,11 @@ vows.describe('OAuth').addBatch({
             "and a post_content_type is specified" : {
               "It should be written as is, with a content length specified, and the encoding should be set to be as specified" : function(oa) {
                 var op= oa._createClient;
-                try { 
+                try {
                   var callbackCalled= false;
                   oa._createClient= function( port, hostname, method, path, headers, sshEnabled ) {
                     assert.equal(headers["Content-Type"], "unicorn/encoded");
-                    assert.equal(headers["Content-length"], 23);  
+                    assert.equal(headers["Content-length"], 23);
                     return {
                       write: function(data) {
                          callbackCalled= true;
@@ -582,7 +618,7 @@ vows.describe('OAuth').addBatch({
          'if no callback is passed' : {
            'it should return a request object': function(oa) {
              var request= oa.delete("http://foo.com/blah", "token", "token_secret")
-             assert.isObject(request); 
+             assert.isObject(request);
              assert.equal(request.method, "DELETE");
              request.end();
            }
@@ -628,7 +664,7 @@ vows.describe('OAuth').addBatch({
               }
               finally {
                 oa._createClient= op;
-              }              
+              }
             }
           },
           'and a 210 response code is received' : {
@@ -648,7 +684,7 @@ vows.describe('OAuth').addBatch({
               }
               finally {
                 oa._createClient= op;
-              }              
+              }
             }
           },
           'And A 301 redirect is received' : {


### PR DESCRIPTION
I may possibly have overlooked it but there doesn't seem to be any option to add custom headers per request or after construction. I went about adding helpers to add and remove custom headers without interfering with the current API or manipulating `_headers` directly.

Apologies for the whitespace :ambulance:, you can suppress it in the diff with `?w=`
