### PR TITLE
Added Support for Generating an XOAuth 1.0 String

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -36,7 +36,7 @@ describe('OAuth1.0',function(){
     );
     oauth.get(
       'https://api.twitter.com/1.1/trends/place.json?id=23424977',
-      'your user toke for this app', //test user token
+      'your user token for this app', //test user token
       'your user secret for this app', //test user secret            
       function (e, data, res){
         if (e) console.error(e);        
@@ -70,6 +70,35 @@ describe('OAuth2',function(){
        done();
      });
    });
+```
+
+## Build XOAuth String
+```javascript
+var Imap = require('imap');
+
+describe('Build XOAuth String',function(){
+  var OAuth = require('OAuth');
+
+  it('tests GMail XOAuth API',function(done){
+    var oauth = new OAuth.OAuth(null, null, 'your application consumer key', 'your application secret', '1.0', null, 'HMAC-SHA1'),
+      imap = new Imap({
+        host: 'imap.googlemail.com',
+        port: 993,
+        xoauth: oauth.buildOAuthString('https://mail.google.com/mail/b/' + email + '/imap/', 'your user token for this app', 'your user secret for this app'),
+        secure: true
+      });
+
+    imap.connect(function(err) {
+      imap.getBoxes(function(err, boxes) {
+        if (e) console.error(e);        
+        console.log(require('util').inspect(boxes));
+        imap.logout();
+        done();
+      });
+    });
+ 
+  });
+});
 ```
 
 Change History

--- a/lib/oauth.js
+++ b/lib/oauth.js
@@ -554,3 +554,10 @@ exports.OAuth.prototype.authHeader= function(url, oauth_token, oauth_token_secre
   var orderedParameters= this._prepareParameters(oauth_token, oauth_token_secret, method, url, {});
   return this._buildAuthorizationHeaders(orderedParameters);
 };
+
+exports.OAuth.prototype.buildOAuthString = function(url, oauth_token, oauth_token_secret) {
+  var orderedParameters = this._prepareParameters(oauth_token, oauth_token_secret, 'GET', url, {}),
+    joinedParameters = this._buildAuthorizationHeaders(orderedParameters).replace(/^OAuth /, '');
+
+  return new Buffer('GET ' + url + ' ' + joinedParameters, 'utf8').toString('base64');
+};

--- a/tests/oauth.js
+++ b/tests/oauth.js
@@ -208,6 +208,18 @@ vows.describe('OAuth').addBatch({
         assert.equal( oa.authHeader("http://somehost.com:3323/foo/poop?bar=foo", "token", "tokensecret"), 'OAuth realm="http://foobar.com/",oauth_consumer_key="consumerkey",oauth_nonce="ybHPeOEkAUJ3k2wJT9Xb43MjtSgTvKqp",oauth_signature_method="HMAC-SHA1",oauth_timestamp="1272399856",oauth_token="token",oauth_version="1.0A",oauth_signature="0rr1LhSxACX2IEWRq3uCb4IwtOs%3D"');
       }
     },
+    'When building a string for xoauth requests': {
+      topic: function () {
+        var oa= new OAuth(null, null, "consumerkey", "consumersecret", "1.0", null, "HMAC-SHA1");
+        oa._getTimestamp= function(){ return "1272399856"; }
+        oa._getNonce= function(){ return "ybHPeOEkAUJ3k2wJT9Xb43MjtSgTvKqp"; }
+        return oa;
+      },
+      'Should return appropritae base64 encoded xoauth string': function (oa) {
+        var b64XOAuthString = new Buffer('GET http://somehost.com:3323/foo/poop?bar=foo oauth_consumer_key="consumerkey",oauth_nonce="ybHPeOEkAUJ3k2wJT9Xb43MjtSgTvKqp",oauth_signature_method="HMAC-SHA1",oauth_timestamp="1272399856",oauth_token="token",oauth_version="1.0",oauth_signature="zeOR0Wsm6EG6XSg0Vw%2FsbpoSib8%3D"', 'utf8').toString('base64');
+        assert.equal( oa.buildOAuthString("http://somehost.com:3323/foo/poop?bar=foo", "token", "tokensecret"), b64XOAuthString);
+      }
+    },
     'When non standard ports are used': {
         topic: function() {
           var oa= new OAuth(null, null, null, null, null, null, "HMAC-SHA1"),


### PR DESCRIPTION
I added a helper method called buildOAuthString which can be used to generate an XOAuth string.

This can be used for interacting with Gmail's SMTP/IMAP via OAuth.
