### PR TITLE
Use hasOwnProperty to prevent erros

### DIFF
--- a/lib/oauth.js
+++ b/lib/oauth.js
@@ -133,6 +133,7 @@ exports.OAuth.prototype._buildAuthorizationHeaders= function(orderedParameters) 
 exports.OAuth.prototype._makeArrayOfArgumentsHash= function(argumentsHash) {
   var argument_pairs= [];
   for(var key in argumentsHash ) {
+    if (argumentsHash.hasOwnProperty(key)) {
        var value= argumentsHash[key];
        if( Array.isArray(value) ) {
          for(var i=0;i<value.length;i++) {
@@ -142,6 +143,7 @@ exports.OAuth.prototype._makeArrayOfArgumentsHash= function(argumentsHash) {
        else {
          argument_pairs[argument_pairs.length]= [key, value];
        }
+    }
   }
   return argument_pairs;  
 } 
@@ -263,7 +265,7 @@ exports.OAuth.prototype._prepareParameters= function( oauth_token, oauth_token_s
   else {
     if( extra_params ) {
       for( var key in extra_params ) {
-           oauthParameters[key]= extra_params[key];
+        if (extra_params.hasOwnProperty(key)) oauthParameters[key]= extra_params[key];
       }
     }
     var parsedUrl= URL.parse( url, false );


### PR DESCRIPTION
If you have other libraries in your project wich use _prototype_ to create custom functions we need to omit that inherited properties in order to get a valid signature
