### PR TITLE
Remove type query parameter from OAuth2 requests.

### DIFF
--- a/lib/oauth2.js
+++ b/lib/oauth2.js
@@ -132,13 +132,12 @@ exports.OAuth2.prototype._executeRequest= function( http_library, options, post_
   if(  options.method == 'POST' && post_body ) {
      request.write(post_body);
   }
-  request.end();  
+  request.end();
 }
 
 exports.OAuth2.prototype.getAuthorizeUrl= function( params ) {
   var params= params || {};
   params['client_id'] = this._clientId;
-  params['type'] = 'web_server';
   return this._baseSite + this._authorizeUrl + "?" + querystring.stringify(params);
 }
 
@@ -146,7 +145,6 @@ exports.OAuth2.prototype.getOAuthAccessToken= function(code, params, callback) {
   var params= params || {};
   params['client_id'] = this._clientId;
   params['client_secret'] = this._clientSecret;
-  params['type']= 'web_server';
   var codeParam = (params.grant_type === 'refresh_token') ? 'refresh_token' : 'code';
   params[codeParam]= code;
 


### PR DESCRIPTION
While the type parameter was required in older versions of the OAuth2
specification, it was removed in version 8. Currently, this breaks OAuth2
against the Dropbox API. Closes #127.

http://tools.ietf.org/html/draft-ietf-oauth-v2-08#section-4.1.1
