### PR TITLE
Create a real error object on bad HTTP response

### DIFF
--- a/lib/oauth.js
+++ b/lib/oauth.js
@@ -33,6 +33,18 @@ exports.OAuth= function(requestUrl, accessUrl, consumerKey, consumerSecret, vers
   this._oauthParameterSeperator = ",";
 };
 
+exports.OAuth.Error= function(url, statusCode, data) {
+  Error.captureStackTrace(this, exports.OAuth.Error);
+  this.name = 'OAuth.Error';
+  this.url = url;
+  this.statusCode = statusCode;
+  this.data = data;
+  this.message = "HTTP Error code " + statusCode + " when requesting " + url;
+};
+
+exports.OAuth.prototype = new Error();
+exports.OAuth.prototype.constructor = exports.OAuth.Error;
+
 exports.OAuthEcho= function(realm, verify_credentials, consumerKey, consumerSecret, version, signatureMethod, nonceSize, customHeaders) {
   this._isEcho = true;
 
@@ -371,7 +383,7 @@ exports.OAuth.prototype._performSecureRequest= function( oauth_token, oauth_toke
             self._performSecureRequest( oauth_token, oauth_token_secret, method, response.headers.location, extra_params, post_body, post_content_type,  callback);
           }
           else {
-            callback({ statusCode: response.statusCode, data: data }, data, response);
+            callback(new exports.OAuth.Error( url, response.statusCode, data ), data, response);
           }
         }
       }


### PR DESCRIPTION
I frequently find myself special-casing the OAuth request error responses, since they are not instances of the Error class.

This change adds a new class, OAuth.Error, and returns it in case of errors in the HTTP requests. It has the same properties as the original Object instance.
