### PR TITLE
sending post_data and receiving Buffers in the content functionality

### DIFF
--- a/lib/oauth.js
+++ b/lib/oauth.js
@@ -336,7 +336,8 @@ exports.OAuth.prototype._performSecureRequest= function( oauth_token, oauth_toke
                        .replace(/\*/g, "%2A");
   }
 
-  headers["Content-length"]= post_body ? Buffer.byteLength(post_body) : 0;
+  // not truthy post_body will always return 0, length is byte length, just getting it differently
+  headers["Content-length"]= post_body ? (Buffer.isBuffer(post_body) ? post_body.length : Buffer.byteLength(post_body)) : 0;
   headers["Content-Type"]= post_content_type;
    
   var path;
@@ -353,7 +354,8 @@ exports.OAuth.prototype._performSecureRequest= function( oauth_token, oauth_toke
   }
 
   if( callback ) {
-    var data=""; 
+    // var data=""; 
+    var data = new Buffer('');
     var self= this;
 
     // Some hosts *cough* google appear to close the connection early / send no content-length header
@@ -378,9 +380,10 @@ exports.OAuth.prototype._performSecureRequest= function( oauth_token, oauth_toke
     }
 
     request.on('response', function (response) {
-      response.setEncoding('utf8');
+      // response.setEncoding('utf8');
       response.on('data', function (chunk) {
-        data+=chunk;
+        // data+=chunk;
+        data = Buffer.concat([data, chunk])
       });
       response.on('end', function () {
         passBackControl( response );
@@ -468,7 +471,7 @@ exports.OAuth.prototype._putOrPost= function(method, url, oauth_token, oauth_tok
     callback= post_content_type;
     post_content_type= null;
   }
-  if( typeof post_body != "string" ) {
+  if( (typeof post_body != "string") && (!Buffer.isBuffer(post_body)) ) {
     post_content_type= "application/x-www-form-urlencoded"
     extra_params= post_body;
     post_body= null;


### PR DESCRIPTION
While fully aware that it's an old topic, i don't see why oauth should operate on utf-8 data, since encoding should be a matter discussed between client application and server.
And since oauth is a kind of middleware, the buffers should be exactly what's needed, since they pass the data as is. Byte by byte.
If the client want's data sent or received in utf8, there's no reason why not to prepare utf data, and send new Buffer(data, 'utf8').

I can't think of a fail scenario right now, but in case you're concerned for old applications i prepared another pull request for that, feel free to choose.
