### PR TITLE
Use of buffers to transfer data - optional

### DIFF
--- a/lib/oauth.js
+++ b/lib/oauth.js
@@ -6,7 +6,7 @@ var crypto= require('crypto'),
     querystring= require('querystring'),
     OAuthUtils= require('./_utils');
 
-exports.OAuth= function(requestUrl, accessUrl, consumerKey, consumerSecret, version, authorize_callback, signatureMethod, nonceSize, customHeaders) {
+exports.OAuth= function(requestUrl, accessUrl, consumerKey, consumerSecret, version, authorize_callback, signatureMethod, nonceSize, customHeaders, inBinaryTransferMode) {
   this._isEcho = false;
 
   this._requestUrl= requestUrl;
@@ -31,6 +31,8 @@ exports.OAuth= function(requestUrl, accessUrl, consumerKey, consumerSecret, vers
   this._clientOptions= this._defaultClientOptions= {"requestTokenHttpMethod": "POST",
                                                     "accessTokenHttpMethod": "POST"};
   this._oauthParameterSeperator = ",";
+
+  this._inBinaryTransferMode = !!inBinaryTransferMode;
 };
 
 exports.OAuthEcho= function(realm, verify_credentials, consumerKey, consumerSecret, version, signatureMethod, nonceSize, customHeaders) {
@@ -337,7 +339,12 @@ exports.OAuth.prototype._performSecureRequest= function( oauth_token, oauth_toke
   }
 
   // not truthy post_body will always return 0, length is byte length, just getting it differently
-  headers["Content-length"]= post_body ? (Buffer.isBuffer(post_body) ? post_body.length : Buffer.byteLength(post_body)) : 0;
+  if (this._inBinaryTransferMode) {
+    headers["Content-length"]= post_body ? post_body.length : 0;
+  } else {
+    headers["Content-length"]= post_body ? Buffer.byteLength(post_body) : 0;
+  }
+  
   headers["Content-Type"]= post_content_type;
    
   var path;
@@ -354,8 +361,7 @@ exports.OAuth.prototype._performSecureRequest= function( oauth_token, oauth_toke
   }
 
   if( callback ) {
-    // var data=""; 
-    var data = new Buffer('');
+    var data = (this._inBinaryTransferMode ? new Buffer("") : "");
     var self= this;
 
     // Some hosts *cough* google appear to close the connection early / send no content-length header
@@ -380,10 +386,15 @@ exports.OAuth.prototype._performSecureRequest= function( oauth_token, oauth_toke
     }
 
     request.on('response', function (response) {
-      // response.setEncoding('utf8');
+      if (!this._inBinaryTransferMode) {
+        response.setEncoding('utf8');
+      }
       response.on('data', function (chunk) {
-        // data+=chunk;
-        data = Buffer.concat([data, chunk])
+        if (this._inBinaryTransferMode) {
+          data = Buffer.concat([data, chunk])
+        } else {
+          data+=chunk;
+        }
       });
       response.on('end', function () {
         passBackControl( response );
@@ -471,7 +482,8 @@ exports.OAuth.prototype._putOrPost= function(method, url, oauth_token, oauth_tok
     callback= post_content_type;
     post_content_type= null;
   }
-  if( (typeof post_body != "string") && (!Buffer.isBuffer(post_body)) ) {
+  if( (!this._inBinaryTransferMode && typeof post_body != "string") 
+    || (this._inBinaryTransferMode && !Buffer.isBuffer(post_body)) ) {
     post_content_type= "application/x-www-form-urlencoded"
     extra_params= post_body;
     post_body= null;


### PR DESCRIPTION
As mentioned, I prepared a version with Buffer use for data transfer optional.

Constructor takes a boolean argument (please notice, that if not provided, the OAuth object will act exactly as before.

Otherwise it will use my changes that enable Buffer data transfer.
