### PR TITLE
Status code 201 is also a valid status code

### DIFF
--- a/lib/oauth2.js
+++ b/lib/oauth2.js
@@ -101,7 +101,7 @@ exports.OAuth2.prototype._executeRequest= function( http_library, options, post_
   function passBackControl( response, result ) {
     if(!callbackCalled) {
       callbackCalled=true;
-      if( response.statusCode != 200 && (response.statusCode != 301) && (response.statusCode != 302) ) {
+      if( response.statusCode != 201 && response.statusCode != 200 && (response.statusCode != 301) && (response.statusCode != 302) ) {
         callback({ statusCode: response.statusCode, data: result });
       } else {
         callback(null, result, response);


### PR DESCRIPTION
If the POST request leads to create a resource, the status code returned will be 201.
Right now, only 200, 301 and 302 are considered valid status codes for a successe.
