### PR TITLE
Add post method for oauth2 module

### DIFF
--- a/lib/oauth2.js
+++ b/lib/oauth2.js
@@ -132,7 +132,7 @@ exports.OAuth2.prototype._executeRequest= function( http_library, options, post_
   if(  options.method == 'POST' && post_body ) {
      request.write(post_body);
   }
-  request.end();  
+  request.end();
 }
 
 exports.OAuth2.prototype.getAuthorizeUrl= function( params ) {
@@ -200,9 +200,9 @@ exports.OAuth2.prototype.post= function(url, access_token, callback) {
   var post_headers= {
     'Content-Type': 'application/x-www-form-urlencoded'
   };
-  var post_data= {
-    this._accessTokenName: access_token
-  };
+  var post_data= {};
+
+  post_data[this._accessTokenName] = access_token;
 
   this._request("POST", url, post_headers, querystring.stringify(post_data), null, callback );
 }


### PR DESCRIPTION
Some site(such as http://open.weibo.com/wiki/Oauth2/get_token_info) only support POST method to get user info by access_token.
