### PR TITLE
Sending original request parameters to callback

### DIFF
--- a/lib/oauth.js
+++ b/lib/oauth.js
@@ -364,14 +364,14 @@ exports.OAuth.prototype._performSecureRequest= function( oauth_token, oauth_toke
       if(!callbackCalled) {
         callbackCalled= true;
         if ( response.statusCode >= 200 && response.statusCode <= 299 ) {
-          callback(null, data, response);
+          callback(null, data, response, orderedParameters);
         } else {
           // Follow 301 or 302 redirects with Location HTTP header
           if((response.statusCode == 301 || response.statusCode == 302) && response.headers && response.headers.location) {
             self._performSecureRequest( oauth_token, oauth_token_secret, method, response.headers.location, extra_params, post_body, post_content_type,  callback);
           }
           else {
-            callback({ statusCode: response.statusCode, data: data }, data, response);
+            callback({ statusCode: response.statusCode, data: data }, data, response, orderedParameters);
           }
         }
       }


### PR DESCRIPTION
In some situations, the caller may want to compare original
parameters sent to an OAuth request with the values mirrored
in a response.  For example, verifying the nonce is the same
to prevent a replay attack.
