### PR TITLE
Allow self-signed certificates for testing purposes

### DIFF
--- a/lib/oauth2.js
+++ b/lib/oauth2.js
@@ -94,6 +94,10 @@ exports.OAuth2.prototype._request= function(method, url, headers, post_body, acc
     headers: realHeaders
   };
 
+  if (parsedUrl.protocol == "https:" && process.env.ALLOW_UNAUTHORIZED_CERTS) {
+    options.rejectUnauthorized = false;
+  }
+
   this._executeRequest( http_library, options, post_body, callback );
 }
 


### PR DESCRIPTION
When testing on my local machine passport-oauth2 against a self-signed server, I always received the following error:

```
Error: DEPTH_ZERO_SELF_SIGNED_CERT at OAuth2Strategy._createOAuthError (/home/ubuntu/reviewer/brivolabs-sam-cork/oauth-demo/node_modules/passport-oauth/node_modules/passport-oauth2/lib/strategy.js:340:17) 
at /home/ubuntu/reviewer/brivolabs-sam-cork/oauth-demo/node_modules/passport-oauth/node_modules/passport-oauth2/lib/strategy.js:173:43 
at /home/ubuntu/reviewer/brivolabs-sam-cork/oauth-demo/node_modules/passport-oauth/node_modules/passport-oauth2/node_modules/oauth/lib/oauth2.js:162:18 
at ClientRequest.<anonymous> (/home/ubuntu/reviewer/brivolabs-sam-cork/oauth-demo/node_modules/passport-oauth/node_modules/passport-oauth2/node_modules/oauth/lib/oauth2.js:133:5) 
at ClientRequest.EventEmitter.emit (events.js:95:17) 
at CleartextStream.socketErrorListener (http.js:1547:9) 
at CleartextStream.EventEmitter.emit (events.js:95:17) 
at SecurePair.<anonymous> (tls.js:1389:19) 
at SecurePair.EventEmitter.emit (events.js:92:17) 
at SecurePair.maybeInitFinished (tls.js:982:10)
```

This fix allows us to use a self-signed certificate if the env variable ALLOW_UNAUTHORIZED_CERTS is set.
I know that there is a env that some nodejs people use to avoid the issue (which is NODE_TLS_REJECT_UNAUTHORIZED set to "0"), but I thought it might be better to have it explicit on oauth.
