### PR TITLE
Fixes a bug when using a parenthesis in the url

### DIFF
--- a/lib/oauth.js
+++ b/lib/oauth.js
@@ -306,6 +306,12 @@ exports.OAuth.prototype._prepareParameters= function( oauth_token, oauth_token_s
 exports.OAuth.prototype._performSecureRequest= function( oauth_token, oauth_token_secret, method, url, extra_params, post_body, post_content_type,  callback ) {
   var orderedParameters= this._prepareParameters(oauth_token, oauth_token_secret, method, url, extra_params);
 
+  url.replace(/\!/g, "%21")
+        .replace(/\'/g, "%27")
+        .replace(/\(/g, "%28")
+        .replace(/\)/g, "%29")
+        .replace(/\*/g, "%2A");
+
   if( !post_content_type ) {
     post_content_type= "application/x-www-form-urlencoded";
   }


### PR DESCRIPTION
Some symbols like parentheses are encoded when making the signature, but wasn't in the request.
When using one of them in a GET parameters, the signature did not match.

This pull request should fix this.

The same bug has been fixed for POST data a year ago in issue #113, with a [great explanation](https://github.com/ciaranj/node-oauth/issues/113#issuecomment-8956629).
