### PR TITLE
update oauth.js to work in strict mode

### DIFF
--- a/lib/oauth.js
+++ b/lib/oauth.js
@@ -166,8 +166,8 @@ exports.OAuth.prototype._sortRequestParams= function(argument_pairs) {
   return argument_pairs;
 }
 
-exports.OAuth.prototype._normaliseRequestParams= function(arguments) {
-  var argument_pairs= this._makeArrayOfArgumentsHash(arguments);
+exports.OAuth.prototype._normaliseRequestParams= function(args) {
+  var argument_pairs= this._makeArrayOfArgumentsHash(args);
   // First encode them #3.4.1.3.2 .1
   for(var i=0;i<argument_pairs.length;i++) {
     argument_pairs[i][0]= this._encodeData( argument_pairs[i][0] );
@@ -372,7 +372,7 @@ exports.OAuth.prototype._performSecureRequest= function( oauth_token, oauth_toke
     // allow this behaviour.
     var allowEarlyClose= OAuthUtils.isAnEarlyCloseHost( parsedUrl.hostname );
     var callbackCalled= false;
-    function passBackControl( response ) {
+    var passBackControl= function( response ) {
       if(!callbackCalled) {
         callbackCalled= true;
         if ( response.statusCode >= 200 && response.statusCode <= 299 ) {


### PR DESCRIPTION
changed arguments to args and function passBackControl to var passBackControl= function

the two changes want to fix this strict errors:

function passBackControl( response ) {
    ^^^^^^^^
SyntaxError: In strict mode code, functions can only be declared at top level or immediately within another function.

exports.OAuth.prototype._normaliseRequestParams= function(arguments) {
                                                          ^^^^^^^^^
SyntaxError: Parameter name eval or arguments is not allowed in strict mode
