### PR TITLE
Remove intermediate hash step for parameters

### DIFF
--- a/lib/oauth.js
+++ b/lib/oauth.js
@@ -135,24 +135,6 @@ exports.OAuth.prototype._buildAuthorizationHeaders= function(orderedParameters) 
   return authHeader;
 }
 
-// Takes an object literal that represents the arguments, and returns an array
-// of argument/value pairs.
-exports.OAuth.prototype._makeArrayOfArgumentsHash= function(argumentsHash) {
-  var argument_pairs= [];
-  for(var key in argumentsHash ) {
-       var value= argumentsHash[key];
-       if( Array.isArray(value) ) {
-         for(var i=0;i<value.length;i++) {
-           argument_pairs[argument_pairs.length]= [key, value[i]];
-         }
-       }
-       else {
-         argument_pairs[argument_pairs.length]= [key, value];
-       }
-  }
-  return argument_pairs;
-}
-
 // Sorts the encoded key value pairs by encoded name, then encoded value
 exports.OAuth.prototype._sortRequestParams= function(argument_pairs) {
   // Sort by name, then value.
@@ -166,8 +148,7 @@ exports.OAuth.prototype._sortRequestParams= function(argument_pairs) {
   return argument_pairs;
 }
 
-exports.OAuth.prototype._normaliseRequestParams= function(arguments) {
-  var argument_pairs= this._makeArrayOfArgumentsHash(arguments);
+exports.OAuth.prototype._normaliseRequestParams= function(argument_pairs) {
   // First encode them #3.4.1.3.2 .1
   for(var i=0;i<argument_pairs.length;i++) {
     argument_pairs[i][0]= this._encodeData( argument_pairs[i][0] );
@@ -254,17 +235,27 @@ exports.OAuth.prototype._createClient= function( port, hostname, method, path, h
   return httpModel.request(options);
 }
 
+exports.OAuth.prototype._safelyAddParameters= function( oauthParameters, key, value ) {
+  if( Array.isArray(value) ){
+    for (var i=0 ; i<value.length; ++i) {
+      this._safelyAddParamaters( oauthParameters, key, value[i]);
+    }
+  } else {
+    oauthParameters.push([key, value]);
+  }
+};
+
 exports.OAuth.prototype._prepareParameters= function( oauth_token, oauth_token_secret, method, url, extra_params ) {
-  var oauthParameters= {
-      "oauth_timestamp":        this._getTimestamp(),
-      "oauth_nonce":            this._getNonce(this._nonceSize),
-      "oauth_version":          this._version,
-      "oauth_signature_method": this._signatureMethod,
-      "oauth_consumer_key":     this._consumerKey
-  };
+  var oauthParameters= [
+      ["oauth_timestamp", this._getTimestamp()],
+      ["oauth_nonce", this._getNonce(this._nonceSize)],
+      ["oauth_version", this._version],
+      ["oauth_signature_method", this._signatureMethod],
+      ["oauth_consumer_key", this._consumerKey]
+  ];
 
   if( oauth_token ) {
-    oauthParameters["oauth_token"]= oauth_token;
+    oauthParameters.push(["oauth_token", oauth_token]);
   }
 
   var sig;
@@ -274,7 +265,7 @@ exports.OAuth.prototype._prepareParameters= function( oauth_token, oauth_token_s
   else {
     if( extra_params ) {
       for( var key in extra_params ) {
-           oauthParameters[key]= extra_params[key];
+           oauthParameters.push([key, extra_params[key]]);
       }
     }
     var parsedUrl= URL.parse( url, false );
@@ -283,22 +274,15 @@ exports.OAuth.prototype._prepareParameters= function( oauth_token, oauth_token_s
       var key2;
       var extraParameters= querystring.parse(parsedUrl.query);
       for(var key in extraParameters ) {
-        var value= extraParameters[key];
-          if( typeof value == "object" ){
-            // TODO: This probably should be recursive
-            for(key2 in value){
-              oauthParameters[key + "[" + key2 + "]"] = value[key2];
-            }
-          } else {
-            oauthParameters[key]= value;
-          }
+          var value= extraParameters[key];
+          this._safelyAddParameters( oauthParameters, key, value );
         }
     }
 
     sig = this._getSignature( method,  url,  this._normaliseRequestParams(oauthParameters), oauth_token_secret);
   }
 
-  var orderedParameters= this._sortRequestParams( this._makeArrayOfArgumentsHash(oauthParameters) );
+  var orderedParameters= this._sortRequestParams( oauthParameters );
   orderedParameters[orderedParameters.length]= ["oauth_signature", sig];
   return orderedParameters;
 }


### PR DESCRIPTION
This should resolve issues caused by incorrect handling of duplicate query and post parameter names and is more performant because we don't need to round-trip the signable arguments through a hash.  We just build the argument_pairs and use those throughout the signature base generation process.
