### PR TITLE
Handle Authorization URL With Already Existing Query Parameter

### DIFF
--- a/lib/oauth2.js
+++ b/lib/oauth2.js
@@ -142,7 +142,7 @@ exports.OAuth2.prototype._executeRequest= function( http_library, options, post_
 exports.OAuth2.prototype.getAuthorizeUrl= function( params ) {
   var params= params || {};
   params['client_id'] = this._clientId;
-  return this._baseSite + this._authorizeUrl + "?" + querystring.stringify(params);
+  return this._baseSite + this._authorizeUrl + (this._authorizeUrl.indexOf('?') > 0 ? '&' : '?') + querystring.stringify(params);
 }
 
 exports.OAuth2.prototype.getOAuthAccessToken= function(code, params, callback) {


### PR DESCRIPTION
Hi there! I'm using this library for one of my projects and ran into an instance where I had an authorization end-point similar to the following: `http://www.example.com/oauth2/authorize?parameter1=value1` where I was hitting an issue when attempting to build the Authorization URL since it was creating the following: `http://www.example.com/oauth2/authorize?parameter1=value1?response_type=code&redirect_uri=REDIRECT_URI&client_id=CLIENT_ID` which is an invalid URL (specifically the `?parameter1=value1?response_type=code` part.

To address this I've added a simple check for the Authorization URL already having the `?` in it which fixed this issue for me. I'm not aware of anywhere else in the OAuth2 spec (specifically the client side) where query parameters already existing on a URL would cause an issue so I've only update the single line.
