### PR TITLE
Add missing grant for OAuth2 first party apps using username and password to get access_token.

### DIFF
--- a/lib/oauth2.js
+++ b/lib/oauth2.js
@@ -147,8 +147,7 @@ exports.OAuth2.prototype.getAuthorizeUrl= function( params ) {
 
 exports.OAuth2.prototype.getOAuthAccessToken= function(code, params, callback) {
   var params= params || {},
-      allowedGrants = ['refresh_token', 'password', 'code', 'client_credentials'],
-      codeParam = (allowedGrants.indexOf(params.grant_type) > -1) ? params.grant_type : 'code';
+      codeParam = params.grant_type;
 
   params[codeParam]= code;
   params['client_id'] = this._clientId;


### PR DESCRIPTION
Adds missing OAuth2 password grant authentication, this helps for first party apps of the OAuth server that have access and/or can be trusted with username/password.
