### PR TITLE
Add the opportunity of proxy handling to the oauth2 module

### DIFF
--- a/lib/oauth2.js
+++ b/lib/oauth2.js
@@ -14,6 +14,14 @@ exports.OAuth2= function(clientId, clientSecret, baseSite, authorizePath, access
   this._accessTokenName= "access_token";
   this._authMethod= "Bearer";
   this._customHeaders = customHeaders || {};
+	
+	//proxy object look like this
+	//proxy : {
+	//	host : 'port',
+	//	port : 'host',
+	//	protocol : 'http' // http / https
+	//}
+	this._proxy = proxy;
   this._useAuthorizationHeaderForGET= false;
 }
 
@@ -86,13 +94,31 @@ exports.OAuth2.prototype._request= function(method, url, headers, post_body, acc
 
   var queryStr= querystring.stringify(parsedUrl.query);
   if( queryStr ) queryStr=  "?" + queryStr;
-  var options = {
-    host:parsedUrl.hostname,
-    port: parsedUrl.port,
-    path: parsedUrl.pathname + queryStr,
-    method: method,
-    headers: realHeaders
-  };
+	
+	var options = {};
+  if (this._proxy && this._proxy.host && this._proxy.port && this._proxy.protocol &&
+     (this._proxy.protocol == 'http' || this._proxy.protocol == 'https')) {
+    options = {
+      host: this._proxy.host,
+      port: this._proxy.port,
+      path: parsedUrl.protocol + "//" + parsedUrl.hostname + ":" + parsedUrl.port + parsedUrl.pathname + queryStr,
+      method: method,
+      headers: realHeaders
+    };
+    if (this._proxy.protocol == 'http') {
+      http_library = http;
+    } else {
+      http_library = https;
+    }
+  } else {
+    options = {
+      host: parsedUrl.hostname,
+      port: parsedUrl.port,
+      path: parsedUrl.pathname + queryStr,
+      method: method,
+      headers: realHeaders
+    };
+  }
 
   this._executeRequest( http_library, options, post_body, callback );
 }


### PR DESCRIPTION
I adjusted the oauth2 module to pass proxy settings as an optional parameter to the constructor.
If proxy settings are available, the options object for the _executeRequest method will be extended with them. 
A sample proxy-object looks like this : 

```
 proxy : {
    host : 'port',
    port : 'host',
    protocol : 'http' // http / https
 }
```
