### PR TITLE
Returning the Content-Location header when getting an access token.

### DIFF
--- a/lib/oauth.js
+++ b/lib/oauth.js
@@ -469,6 +469,8 @@ exports.OAuth.prototype.getOAuthAccessToken= function(oauth_token, oauth_token_s
            delete results["oauth_token"];
            var oauth_access_token_secret= results["oauth_token_secret"];
            delete results["oauth_token_secret"];
+           if (response.headers["content-location"])
+             results["content-location"] = response.headers["content-location"];
            callback(null, oauth_access_token, oauth_access_token_secret, results );
          }
    })


### PR DESCRIPTION
This is useful for some providers who return the authenticated user's
URL in the `Content-Location` header, and do not provide any other way of
finding out who you're authenticated as.

I considered simply returning all the headers, since someone _might_ want access to other headers in the future... But that seemed like exposing too much. I dunno.
