### PR TITLE
Ability to set some custom http(s) options

### DIFF
--- a/lib/oauth.js
+++ b/lib/oauth.js
@@ -379,7 +379,6 @@ exports.OAuth.prototype._performSecureRequest= function( oauth_token, oauth_toke
   if( !parsedUrl.pathname  || parsedUrl.pathname == "" ) parsedUrl.pathname ="/";
   if( parsedUrl.query ) path= parsedUrl.pathname + "?"+ parsedUrl.query ;
   else path= parsedUrl.pathname;
-  console.log(headers);
   var request;
   if( parsedUrl.protocol == "https:" ) {
     request= this._createClient(parsedUrl.port, parsedUrl.hostname, method, path, headers, true);


### PR DESCRIPTION
Hi,

I needed to use SSL client authentication with a service I was calling for oAuth 1.0a.  The service had added standard https SSL client auth over top of oAuth.  The node modules support it so I've added the ability to set some options of you need to.

I would be much appreciative if this could be merged in and pushed to NPM please.

Regards

Geoff
