### PR TITLE
Feature/support for access token renewal

### DIFF
--- a/lib/oauth.js
+++ b/lib/oauth.js
@@ -493,6 +493,27 @@ exports.OAuth.prototype.getOAuthAccessToken= function(oauth_token, oauth_token_s
    })
 }
 
+// As per http://oauth.googlecode.com/svn/spec/ext/session/1.0/drafts/1/spec.html
+exports.OAuth.prototype.refreshOAuthAccessToken= function (oauth_token, oauth_token_secret, oauth_session_handle, callback) {
+
+  var extraParams= {};
+
+  extraParams.oauth_session_handle = oauth_session_handle;
+
+  this._performSecureRequest( oauth_token, oauth_token_secret, this._clientOptions.accessTokenHttpMethod, this._accessUrl, extraParams, null, null, function(error, data, response) {
+         if( error ) callback(error);
+         else {
+           var results= querystring.parse( data );
+           var oauth_access_token= results["oauth_token"];
+           delete results["oauth_token"];
+           var oauth_access_token_secret= results["oauth_token_secret"];
+           delete results["oauth_token_secret"];
+           callback(null, oauth_access_token, oauth_access_token_secret, results );
+         }
+   });
+
+};
+
 // Deprecated
 exports.OAuth.prototype.getProtectedResource= function(url, method, oauth_token, oauth_token_secret, callback) {
   this._performSecureRequest( oauth_token, oauth_token_secret, method, url, null, "", null, callback );


### PR DESCRIPTION
added a similar method for supporting 

http://oauth.googlecode.com/svn/spec/ext/session/1.0/drafts/1/spec.html#anchor4
