### PR TITLE
Allow clients to specify an HTTP Agent to use.

### DIFF
--- a/lib/oauth.js
+++ b/lib/oauth.js
@@ -427,6 +427,7 @@ exports.OAuth.prototype._performSecureRequest= function( oauth_token, oauth_toke
       request.write(post_body);
     }
     request.end();
+    return request;
   }
   else {
     if( (method == "POST" || method =="PUT") && post_body != null && post_body != "" ) {

--- a/lib/oauth.js
+++ b/lib/oauth.js
@@ -245,7 +245,8 @@ exports.OAuth.prototype._createClient= function( port, hostname, method, path, h
     port: port,
     path: path,
     method: method,
-    headers: headers
+    headers: headers,
+    agent: this._clientOptions.agent
   };
   var httpModel;
   if( sslEnabled ) {

--- a/lib/oauth.js
+++ b/lib/oauth.js
@@ -29,10 +29,10 @@ exports.OAuth= function(requestUrl, accessUrl, consumerKey, consumerSecret, vers
   this._signatureMethod= signatureMethod;
   this._nonceSize= nonceSize || 32;
   this._headers= customHeaders || {"Accept" : "*/*",
-                                   "Connection" : "close",
                                    "User-Agent" : "Node authentication"}
   this._clientOptions= this._defaultClientOptions= {"requestTokenHttpMethod": "POST",
                                                     "accessTokenHttpMethod": "POST",
+                                                    "agent": undefined,
                                                     "followRedirects": true};
   this._oauthParameterSeperator = ",";
 };


### PR DESCRIPTION
This allows users to provide the socket keepalive behavior they would like. For instance, one can specify a keepaliveagent in order to preserve connections and save reconnect time. Or one can specify agent: false for streaming endpoints (like the Twitter Streaming API) where the sockets should not be entered into a pool.
