### PR TITLE
Update to allow custom options for client creation

### DIFF
--- a/lib/oauth.js
+++ b/lib/oauth.js
@@ -251,8 +251,8 @@ exports.OAuth.prototype._createClient= function( port, hostname, method, path, h
   // This only merges properties in options if they are not already
   // set.
   for (var idx in this._customClientOptions) {
-    if (typeof options.idx == 'undefined') {
-      options.idx = this._customClientOptions.idx;
+    if (typeof options[idx] == 'undefined') {
+      options[idx] = this._customClientOptions[idx];
     }
   }
   var httpModel;

--- a/lib/oauth.js
+++ b/lib/oauth.js
@@ -6,7 +6,7 @@ var crypto= require('crypto'),
     querystring= require('querystring'),
     OAuthUtils= require('./_utils');
 
-exports.OAuth= function(requestUrl, accessUrl, consumerKey, consumerSecret, version, authorize_callback, signatureMethod, nonceSize, customHeaders) {
+exports.OAuth= function(requestUrl, accessUrl, consumerKey, consumerSecret, version, authorize_callback, signatureMethod, nonceSize, customHeaders, customOptions) {
   this._isEcho = false;
 
   this._requestUrl= requestUrl;
@@ -34,6 +34,7 @@ exports.OAuth= function(requestUrl, accessUrl, consumerKey, consumerSecret, vers
   this._clientOptions= this._defaultClientOptions= {"requestTokenHttpMethod": "POST",
                                                     "accessTokenHttpMethod": "POST",
                                                     "followRedirects": true};
+  this._customClientOptions = customOptions || {};
   this._oauthParameterSeperator = ",";
 };
 
@@ -247,6 +248,13 @@ exports.OAuth.prototype._createClient= function( port, hostname, method, path, h
     method: method,
     headers: headers
   };
+  // This only merges properties in options if they are not already
+  // set.
+  for (var idx in this._customClientOptions) {
+    if (typeof option.idx == 'undefined') {
+      options.idx = this._customClientOptions.idx;
+    }
+  }
   var httpModel;
   if( sslEnabled ) {
     httpModel= https;

--- a/lib/oauth.js
+++ b/lib/oauth.js
@@ -251,7 +251,7 @@ exports.OAuth.prototype._createClient= function( port, hostname, method, path, h
   // This only merges properties in options if they are not already
   // set.
   for (var idx in this._customClientOptions) {
-    if (typeof option.idx == 'undefined') {
+    if (typeof options.idx == 'undefined') {
       options.idx = this._customClientOptions.idx;
     }
   }


### PR DESCRIPTION
Gives a user the ability to add custom client options when creating a new https.request() or http.request()