### PR TITLE
add optional OAuth(http, https, options) constructor signature

### DIFF
--- a/lib/oauth.js
+++ b/lib/oauth.js
@@ -1,12 +1,30 @@
 var crypto= require('crypto'),
     sha1= require('./sha1'),
-    http= require('http'),
-    https= require('https'),
     URL= require('url'),
     querystring= require('querystring'),
     OAuthUtils= require('./_utils');
 
 exports.OAuth= function(requestUrl, accessUrl, consumerKey, consumerSecret, version, authorize_callback, signatureMethod, nonceSize, customHeaders) {
+// exports.OAuth= function(http, https, options)
+// exports.OAuth= function(options)
+  if (arguments.length <= 3) {
+    var options = (arguments.length == 3) ? arguments[2] : arguments[0];
+    customHeaders = options.customHeaders;
+    nonceSize = options.nonceSize;
+    signatureMethod = options.signatureMethod;
+    authorize_callback = options.authorize_callback;
+    version = options.version;
+    consumerSecret = options.consumerSecret;
+    consumerKey = options.consumerKey;
+    accessUrl = options.accessUrl;
+    requestUrl = options.requestUrl;
+    this._http = (arguments.length == 3) ? arguments[0] : null;
+    this._https = (arguments.length == 3) ? arguments[1] : null;
+  } else {
+    this._http = require('http');
+    this._https = require('https');
+  }
+
   this._isEcho = false;
 
   this._requestUrl= requestUrl;
@@ -249,9 +267,9 @@ exports.OAuth.prototype._createClient= function( port, hostname, method, path, h
   };
   var httpModel;
   if( sslEnabled ) {
-    httpModel= https;
+    httpModel= this._https;
   } else {
-    httpModel= http;
+    httpModel= this._http;
   }
   return httpModel.request(options);
 }

--- a/lib/oauth.js
+++ b/lib/oauth.js
@@ -8,6 +8,8 @@ exports.OAuth= function(requestUrl, accessUrl, consumerKey, consumerSecret, vers
 // exports.OAuth= function(http, https, options)
 // exports.OAuth= function(options)
   if (arguments.length <= 3) {
+    this._http = (arguments.length == 3) ? arguments[0] : null;
+    this._https = (arguments.length == 3) ? arguments[1] : null;
     var options = (arguments.length == 3) ? arguments[2] : arguments[0];
     customHeaders = options.customHeaders;
     nonceSize = options.nonceSize;
@@ -18,8 +20,6 @@ exports.OAuth= function(requestUrl, accessUrl, consumerKey, consumerSecret, vers
     consumerKey = options.consumerKey;
     accessUrl = options.accessUrl;
     requestUrl = options.requestUrl;
-    this._http = (arguments.length == 3) ? arguments[0] : null;
-    this._https = (arguments.length == 3) ? arguments[1] : null;
   } else {
     this._http = require('http');
     this._https = require('https');

--- a/lib/oauth.js
+++ b/lib/oauth.js
@@ -452,7 +452,7 @@ exports.OAuth.prototype._performSecureRequest= function( oauth_token, oauth_toke
     return request;
   }
 
-  return;
+  return request;
 }
 
 exports.OAuth.prototype.setClientOptions= function(options) {

--- a/lib/oauth2.js
+++ b/lib/oauth2.js
@@ -1,19 +1,34 @@
 var querystring= require('querystring'),
     crypto= require('crypto'),
-    https= require('https'),
-    http= require('http'),
     URL= require('url'),
     OAuthUtils= require('./_utils');
 
 exports.OAuth2= function(clientId, clientSecret, baseSite, authorizePath, accessTokenPath, customHeaders) {
-  this._clientId= clientId;
-  this._clientSecret= clientSecret;
-  this._baseSite= baseSite;
-  this._authorizeUrl= authorizePath || "/oauth/authorize";
-  this._accessTokenUrl= accessTokenPath || "/oauth/access_token";
+// exports.OAuth= function(http, https, options)
+// exports.OAuth= function(options)
+  if (arguments.length <= 3 && typeof arguments[0] === 'object' && arguments[0]) {
+    var options = (arguments.length == 3) ? arguments[2] : arguments[0];
+    this._clientId= options.clientId;
+    this._clientSecret= options.clientSecret;
+    this._baseSite= options.baseSite;
+    this._authorizeUrl= options.authorizePath || "/oauth/authorize";
+    this._accessTokenUrl= options.accessTokenPath || "/oauth/access_token";
+    this._customHeaders = options.customHeaders || {};
+    this._http = (arguments.length == 3) ? arguments[0] : null;
+    this._https = (arguments.length == 3) ? arguments[1] : null;
+  } else {
+    this._clientId= clientId;
+    this._clientSecret= clientSecret;
+    this._baseSite= baseSite;
+    this._authorizeUrl= authorizePath || "/oauth/authorize";
+    this._accessTokenUrl= accessTokenPath || "/oauth/access_token";
+    this._customHeaders = customHeaders || {};
+    this._http = require('http');
+    this._https = require('https');
+  }
+
   this._accessTokenName= "access_token";
   this._authMethod= "Bearer";
-  this._customHeaders = customHeaders || {};
   this._useAuthorizationHeaderForGET= false;
 }
 
@@ -50,10 +65,10 @@ exports.OAuth2.prototype.buildAuthHeader= function(token) {
 };
 
 exports.OAuth2.prototype._chooseHttpLibrary= function( parsedUrl ) {
-  var http_library= https;
+  var http_library= this._https;
   // As this is OAUth2, we *assume* https unless told explicitly otherwise.
   if( parsedUrl.protocol != "https:" ) {
-    http_library= http;
+    http_library= this._http;
   }
   return http_library;
 };

--- a/lib/oauth2.js
+++ b/lib/oauth2.js
@@ -7,6 +7,8 @@ exports.OAuth2= function(clientId, clientSecret, baseSite, authorizePath, access
 // exports.OAuth= function(http, https, options)
 // exports.OAuth= function(options)
   if (arguments.length <= 3 && typeof arguments[0] === 'object' && arguments[0]) {
+    this._http = (arguments.length == 3) ? arguments[0] : null;
+    this._https = (arguments.length == 3) ? arguments[1] : null;
     var options = (arguments.length == 3) ? arguments[2] : arguments[0];
     this._clientId= options.clientId;
     this._clientSecret= options.clientSecret;
@@ -14,8 +16,6 @@ exports.OAuth2= function(clientId, clientSecret, baseSite, authorizePath, access
     this._authorizeUrl= options.authorizePath || "/oauth/authorize";
     this._accessTokenUrl= options.accessTokenPath || "/oauth/access_token";
     this._customHeaders = options.customHeaders || {};
-    this._http = (arguments.length == 3) ? arguments[0] : null;
-    this._https = (arguments.length == 3) ? arguments[1] : null;
   } else {
     this._clientId= clientId;
     this._clientSecret= clientSecret;


### PR DESCRIPTION
This change makes it possible to use this module with mock HTTP and HTTPS implementations and be actually useful in a thoroughly tested project which has integration tests independent on the actual network. It basically introduces the missing **dependency injection** possiblity.

``` javascript
var http_mock = new MockHttp();
var https_mock = new MockHttps();

var oa = new oauth.OAuth(http_mock, https_mock, {
  consumerKey: '…',
  consumerSecret: '…',
  signatureMethod: 'PLAINTEXT'
  // + other options
});
```

In production, the module would be used simply as

``` javascript
var oa = new oauth.OAuth({
  consumerKey: '…',
  consumerSecret: '…',
  signatureMethod: 'PLAINTEXT'
  // + other options
});
```

…or with explicitly provided HTTP/HTTPS implementations…

``` javascript
var http = require('http');
var https = require('https');

var oa = new oauth.OAuth(http, https, {
  consumerKey: '…',
  consumerSecret: '…',
  signatureMethod: 'PLAINTEXT'
  // + other options
});
```

There are no regressions introduced to dependent packages as the original constructor signature has been preserved for backward compatibility.

(The `OAuth2` constructor is modified in the same fashion.)
