### PR TITLE
Fixed a bug where the _preformSecureRequest method was implicitly setting the Content-Type header...

### DIFF
--- a/lib/oauth.js
+++ b/lib/oauth.js
@@ -308,8 +308,9 @@ exports.OAuth.prototype._prepareParameters= function( oauth_token, oauth_token_s
 exports.OAuth.prototype._performSecureRequest= function( oauth_token, oauth_token_secret, method, url, extra_params, post_body, post_content_type,  callback ) {
   var orderedParameters= this._prepareParameters(oauth_token, oauth_token_secret, method, url, extra_params);
 
-  if( !post_content_type ) {
-    post_content_type= "application/x-www-form-urlencoded";
+    // if a content_type has not been set, set one only if the request method is POST or PUT
+  if( !post_content_type && (method === "POST" || method === "PUT")) {
+      post_content_type = "application/x-www-form-urlencoded";
   }
   var parsedUrl= URL.parse( url, false );
   if( parsedUrl.protocol == "http:" && !parsedUrl.port ) parsedUrl.port= 80;
@@ -359,7 +360,10 @@ exports.OAuth.prototype._performSecureRequest= function( oauth_token, oauth_toke
       headers["Content-length"]= 0;
   }
 
-  headers["Content-Type"]= post_content_type;
+    if (post_content_type) {
+        headers["Content-Type"]= post_content_type;
+    }
+
 
   var path;
   if( !parsedUrl.pathname  || parsedUrl.pathname == "" ) parsedUrl.pathname ="/";
@@ -483,8 +487,23 @@ exports.OAuth.prototype.delete= function(url, oauth_token, oauth_token_secret, c
   return this._performSecureRequest( oauth_token, oauth_token_secret, "DELETE", url, null, "", null, callback );
 }
 
-exports.OAuth.prototype.get= function(url, oauth_token, oauth_token_secret, callback) {
-  return this._performSecureRequest( oauth_token, oauth_token_secret, "GET", url, null, "", null, callback );
+exports.OAuth.prototype.get= function(url, oauth_token, oauth_token_secret, content_type, callback) {
+    // The content_type parameter has been added.
+    // Older versions of the library had the callback in the place of content_type, so less parameters.
+    // To keep the coding style similar, i did not add the content_type as the last parameter. This could cause problems with backward compatibility.
+    // So I'm trying to find out if the content_type is really a string or if it is the callback.
+    // This makes content_type optional.
+    var requestCallback,
+        requestContentType;
+    if (callback === undefined) {
+        requestCallback = content_type;
+        requestContentType = null;
+    } else {
+        requestCallback = callback;
+        requestContentType = content_type;
+    }
+
+    return this._performSecureRequest( oauth_token, oauth_token_secret, "GET", url, null, "", requestContentType, requestCallback );
 }
 
 exports.OAuth.prototype._putOrPost= function(method, url, oauth_token, oauth_token_secret, post_body, post_content_type, callback) {


### PR DESCRIPTION
to "application/x-www-form-urlencoded" even for GET requests (for which one could not have configured the Content-Type), even if this was not configured on the reuqest. This could have the side effect that some servers were denying GET requests (e.g. JIRA REST API) as this value is not acceptable for GET.

Also, implemented the possibility to configure the Content-Type for GET requests as well. The change is backward compatible.