### PR TITLE
Timing bug workaround for node.js 0.11 / io.js 1.1.0

### DIFF
--- a/lib/oauth2.js
+++ b/lib/oauth2.js
@@ -109,7 +109,12 @@ exports.OAuth2.prototype._request= function(method, url, headers, post_body, acc
     headers: realHeaders
   };
 
-  this._executeRequest( http_library, options, post_body, callback );
+  // Workaround for https://github.com/iojs/io.js/issues/712#issuecomment-72883863
+  // setImmediate would also work
+  // process.nextTick will NOT work
+  setTimeout(function () {
+    this._executeRequest( http_library, options, post_body, callback );
+  }, 0);
 }
 
 exports.OAuth2.prototype._executeRequest= function( http_library, options, post_body, callback ) {


### PR DESCRIPTION
In connection with https://github.com/iojs/io.js/issues/712#issuecomment-72883863 I've found that wrapping this method solves a timing bug that appears to be deep in the bowels of node (or perhaps it is somewhere in oauth2, but seeing that it comes from C code, I don't think that's the case).

I can faithfully reproduce the bug, but haven't been able to isolate it outside of passport / oauth2 (probably due to the nature of the timing and the number of callbacks).

node v0.10.35 does not manifest the error.