### PR TITLE
Simple fix to check and add tunnelAgent based on http_proxy

### DIFF
--- a/lib/oauth.js
+++ b/lib/oauth.js
@@ -247,12 +247,36 @@ exports.OAuth.prototype._createClient= function( port, hostname, method, path, h
     method: method,
     headers: headers
   };
+
   var httpModel;
   if( sslEnabled ) {
     httpModel= https;
   } else {
     httpModel= http;
   }
+
+  if (process.env.http_proxy) {
+    var tunnel = require("tunnel");
+    var tunProxy = process.env.http_proxy, idx = tunProxy.indexOf("://");
+    var pHostPort = (tunProxy.substring(idx+3)).split(":");
+
+    if (httpModel === https) {
+      options.agent = tunnel.httpsOverHttp({
+        proxy : {
+          host : pHostPort[0],
+          port : pHostPort[1]
+        }
+      });
+    } else {
+      options.agent = tunnel.httpOverHttp({
+        proxy : {
+          host : pHostPort[0],
+          port : pHostPort[1]
+        }
+      });
+    }
+  }
+
   return httpModel.request(options);
 }
 

--- a/lib/oauth2.js
+++ b/lib/oauth2.js
@@ -109,6 +109,28 @@ exports.OAuth2.prototype._request= function(method, url, headers, post_body, acc
     headers: realHeaders
   };
 
+  if (process.env.http_proxy) {
+    var tunnel = require("tunnel");
+    var tunProxy = process.env.http_proxy, idx = tunProxy.indexOf("://");
+    var pHostPort = (tunProxy.substring(idx+3)).split(":");
+
+    if (http_library === https) {
+      options.agent = tunnel.httpsOverHttp({
+        proxy : {
+          host : pHostPort[0],
+          port : pHostPort[1]
+        }
+      });
+    } else {
+      options.agent = tunnel.httpOverHttp({
+        proxy : {
+          host : pHostPort[0],
+          port : pHostPort[1]
+        }
+      });
+    }
+  }
+
   this._executeRequest( http_library, options, post_body, callback );
 }
 

--- a/package.json
+++ b/package.json
@@ -1,19 +1,29 @@
-{ "name" : "oauth"
-, "description" : "Library for interacting with OAuth 1.0, 1.0A, 2 and Echo.  Provides simplified client access and allows for construction of more complex apis and OAuth providers."
-, "version" : "0.9.12"
-, "directories" : { "lib" : "./lib" }
-, "main" : "index.js"
-, "author" : "Ciaran Jessup <ciaranj@gmail.com>"
-, "repository" : { "type":"git", "url":"http://github.com/ciaranj/node-oauth.git" }
-, "devDependencies": {
+{
+  "name": "oauth",
+  "description": "Library for interacting with OAuth 1.0, 1.0A, 2 and Echo.  Provides simplified client access and allows for construction of more complex apis and OAuth providers.",
+  "version": "0.9.12",
+  "directories": {
+    "lib": "./lib"
+  },
+  "main": "index.js",
+  "author": "Ciaran Jessup <ciaranj@gmail.com>",
+  "repository": {
+    "type": "git",
+    "url": "http://github.com/ciaranj/node-oauth.git"
+  },
+  "devDependencies": {
     "vows": "0.5.x"
-  }
-, "scripts": {
+  },
+  "scripts": {
     "test": "make test"
-  }
-, "licenses" :
-  [ { "type" : "MIT"
-    , "url" : "http://github.com/ciaranj/node-oauth/raw/master/LICENSE"
+  },
+  "licenses": [
+    {
+      "type": "MIT",
+      "url": "http://github.com/ciaranj/node-oauth/raw/master/LICENSE"
     }
-  ]
+  ],
+  "dependencies": {
+    "tunnel": "0.0.3"
+  }
 }


### PR DESCRIPTION
Just added functionality to check for http_proxy environment variable and, create agent object based on 'tunnel' module. I have done this exclusively because, 'passport-twitter' and 'passport-facebook' authentication modules which depend on 'node-oauth' were not working behind corporate proxy. This seem to fix the issue and, I can see the complete authentication flow happening.