### PR TITLE
createCredentials is deprecated in nodejs version 0.12.x

### DIFF
--- a/lib/oauth2.js
+++ b/lib/oauth2.js
@@ -60,7 +60,6 @@ exports.OAuth2.prototype._chooseHttpLibrary= function( parsedUrl ) {
 
 exports.OAuth2.prototype._request= function(method, url, headers, post_body, access_token, callback) {
 
-  var creds = crypto.createCredentials({ });
   var parsedUrl= URL.parse( url, true );
   if( parsedUrl.protocol == "https:" && !parsedUrl.port ) {
     parsedUrl.port= 443;


### PR DESCRIPTION
Remove credential creation as it seems not to be used and is deprecated in nodejs v12