### PR TITLE
support http/https proxies with oauth2, by using request/request.

### DIFF
--- a/lib/oauth2.js
+++ b/lib/oauth2.js
@@ -1,9 +1,6 @@
 var querystring= require('querystring'),
-    crypto= require('crypto'),
-    https= require('https'),
-    http= require('http'),
-    URL= require('url'),
-    OAuthUtils= require('./_utils');
+    request= require('request'),
+    URL= require('url');
 
 exports.OAuth2= function(clientId, clientSecret, baseSite, authorizePath, accessTokenPath, customHeaders) {
   this._clientId= clientId;
@@ -49,24 +46,9 @@ exports.OAuth2.prototype.buildAuthHeader= function(token) {
   return this._authMethod + ' ' + token;
 };
 
-exports.OAuth2.prototype._chooseHttpLibrary= function( parsedUrl ) {
-  var http_library= https;
-  // As this is OAUth2, we *assume* https unless told explicitly otherwise.
-  if( parsedUrl.protocol != "https:" ) {
-    http_library= http;
-  }
-  return http_library;
-};
-
 exports.OAuth2.prototype._request= function(method, url, headers, post_body, access_token, callback) {
 
   var parsedUrl= URL.parse( url, true );
-  if( parsedUrl.protocol == "https:" && !parsedUrl.port ) {
-    parsedUrl.port= 443;
-  }
-
-  var http_library= this._chooseHttpLibrary( parsedUrl );
-
 
   var realHeaders= {};
   for( var key in this._customHeaders ) {
@@ -83,74 +65,24 @@ exports.OAuth2.prototype._request= function(method, url, headers, post_body, acc
     realHeaders['User-Agent'] = 'Node-oauth';
   }
 
-  if( post_body ) {
-      if ( Buffer.isBuffer(post_body) ) {
-          realHeaders["Content-Length"]= post_body.length;
-      } else {
-          realHeaders["Content-Length"]= Buffer.byteLength(post_body);
-      }
-  } else {
-      realHeaders["Content-length"]= 0;
-  }
-
   if( access_token && !('Authorization' in realHeaders)) {
     if( ! parsedUrl.query ) parsedUrl.query= {};
     parsedUrl.query[this._accessTokenName]= access_token;
   }
 
-  var queryStr= querystring.stringify(parsedUrl.query);
-  if( queryStr ) queryStr=  "?" + queryStr;
-  var options = {
-    host:parsedUrl.hostname,
-    port: parsedUrl.port,
-    path: parsedUrl.pathname + queryStr,
-    method: method,
-    headers: realHeaders
-  };
-
-  this._executeRequest( http_library, options, post_body, callback );
-}
-
-exports.OAuth2.prototype._executeRequest= function( http_library, options, post_body, callback ) {
-  // Some hosts *cough* google appear to close the connection early / send no content-length header
-  // allow this behaviour.
-  var allowEarlyClose= OAuthUtils.isAnEarlyCloseHost(options.host);
-  var callbackCalled= false;
-  function passBackControl( response, result ) {
-    if(!callbackCalled) {
-      callbackCalled=true;
-      if( response.statusCode != 200 && (response.statusCode != 301) && (response.statusCode != 302) ) {
-        callback({ statusCode: response.statusCode, data: result });
-      } else {
-        callback(null, result, response);
-      }
+  request[method.toLowerCase()]({
+    uri: parsedUrl,
+    headers: realHeaders,
+    body: post_body
+  }, function(err, response, body){
+    if(err){
+      callback(err);
+    } else if( response.statusCode != 200 && (response.statusCode != 301) && (response.statusCode != 302) ) {
+        callback({ statusCode: response.statusCode, data: body });
+    } else {
+      callback(null, body, response);
     }
-  }
-
-  var result= "";
-
-  var request = http_library.request(options, function (response) {
-    response.on("data", function (chunk) {
-      result+= chunk
-    });
-    response.on("close", function (err) {
-      if( allowEarlyClose ) {
-        passBackControl( response, result );
-      }
-    });
-    response.addListener("end", function () {
-      passBackControl( response, result );
-    });
   });
-  request.on('error', function(e) {
-    callbackCalled= true;
-    callback(e);
-  });
-
-  if( (options.method == 'POST' || options.method == 'PUT') && post_body ) {
-     request.write(post_body);
-  }
-  request.end();
 }
 
 exports.OAuth2.prototype.getAuthorizeUrl= function( params ) {

--- a/package.json
+++ b/package.json
@@ -8,6 +8,9 @@
 , "devDependencies": {
     "vows": "0.5.x"
   }
+, "dependencies": {
+    "request": "^2.54.0"
+  }
 , "scripts": {
     "test": "make test"
   }

--- a/tests/oauth2.js
+++ b/tests/oauth2.js
@@ -2,6 +2,7 @@ var vows = require('vows'),
     assert = require('assert'),
     https = require('https'),
     OAuth2= require('../lib/oauth2').OAuth2,
+    request = require('request'),
     url = require('url');
 
 vows.describe('OAuth2').addBatch({
@@ -127,7 +128,7 @@ vows.describe('OAuth2').addBatch({
           { 'SomeHeader': '123' }),
       'When GETing': {
         'we should see the custom headers mixed into headers property in options passed to http-library' : function(oa) {
-          oa._executeRequest= function( http_library, options, callback ) {
+          request.get = function(options, callback) {
             assert.equal(options.headers["SomeHeader"], "123");
           };
           oa.get("", {});
@@ -139,96 +140,55 @@ vows.describe('OAuth2').addBatch({
         'When POSTing': {
           'we should see a given string being sent to the request' : function(oa) {
             var bodyWritten= false;
-            oa._chooseHttpLibrary= function() {
-              return {
-                request: function(options) {
-                  assert.equal(options.headers["Content-Type"], "text/plain");
-                  assert.equal(options.headers["Content-Length"], 26);
-                  assert.equal(options.method, "POST");
-                  return  {
-                    end: function() {},
-                    on: function() {},
-                    write: function(body) {
-                      bodyWritten= true;
-                      assert.isNotNull(body);
-                      assert.equal(body, "THIS_IS_A_POST_BODY_STRING")
-                    }
-                  }
-                }
-              };
-            }
-            oa._request("POST", "", {"Content-Type":"text/plain"}, "THIS_IS_A_POST_BODY_STRING");
+            request.post = function(options, callback) {
+              assert.equal(options.headers["Content-Type"], "text/plain");
+              callback(null, {statusCode: 200}, options.body);
+            };
+            oa._request("POST", "", {"Content-Type":"text/plain"}, "THIS_IS_A_POST_BODY_STRING", null, function(err, body){
+              bodyWritten= true;
+              assert.equal(body, "THIS_IS_A_POST_BODY_STRING")
+            });
             assert.ok( bodyWritten );
           },
           'we should see a given buffer being sent to the request' : function(oa) {
             var bodyWritten= false;
-            oa._chooseHttpLibrary= function() {
-              return {
-                request: function(options) {
-                  assert.equal(options.headers["Content-Type"], "application/octet-stream");
-                  assert.equal(options.headers["Content-Length"], 4);
-                  assert.equal(options.method, "POST");
-                  return  {
-                    end: function() {},
-                    on: function() {},
-                    write: function(body) {
-                      bodyWritten= true;
-                      assert.isNotNull(body);
-                      assert.equal(4, body.length)
-                    }
-                  }
-                }
-              };
-            }
-            oa._request("POST", "", {"Content-Type":"application/octet-stream"}, new Buffer([1,2,3,4]));
+            request.post = function(options, callback) {
+              assert.equal(options.headers["Content-Type"], "application/octet-stream");
+              callback(null, {statusCode: 200}, options.body);
+            };
+            oa._request("POST", "", {"Content-Type":"application/octet-stream"}, new Buffer([1,2,3,4]), null, function(err, body){
+              bodyWritten= true;
+              assert.isNotNull(body);
+              assert.equal(4, body.length)
+            });
             assert.ok( bodyWritten );
           }
         },
         'When PUTing': {
           'we should see a given string being sent to the request' : function(oa) {
             var bodyWritten= false;
-            oa._chooseHttpLibrary= function() {
-              return {
-                request: function(options) {
-                  assert.equal(options.headers["Content-Type"], "text/plain");
-                  assert.equal(options.headers["Content-Length"], 25);
-                  assert.equal(options.method, "PUT");
-                  return  {
-                    end: function() {},
-                    on: function() {},
-                    write: function(body) {
-                      bodyWritten= true;
-                      assert.isNotNull(body);
-                      assert.equal(body, "THIS_IS_A_PUT_BODY_STRING")
-                    }
-                  }
-                }
-              };
-            }
-            oa._request("PUT", "", {"Content-Type":"text/plain"}, "THIS_IS_A_PUT_BODY_STRING");
+            request.put = function(options, callback) {
+              assert.equal(options.headers["Content-Type"], "text/plain");
+              callback(null, {statusCode: 200}, options.body);
+            };
+            oa._request("PUT", "", {"Content-Type":"text/plain"}, "THIS_IS_A_PUT_BODY_STRING", null, function(err, body){
+              bodyWritten= true;
+              assert.isNotNull(body);
+              assert.equal(body, "THIS_IS_A_PUT_BODY_STRING");
+            });
             assert.ok( bodyWritten );
           },
           'we should see a given buffer being sent to the request' : function(oa) {
             var bodyWritten= false;
-            oa._chooseHttpLibrary= function() {
-              return {
-                request: function(options) {
-                  assert.equal(options.headers["Content-Type"], "application/octet-stream");
-                  assert.equal(options.headers["Content-Length"], 4);
-                  assert.equal(options.method, "PUT");
-                  return  {
-                    end: function() {},
-                    on: function() {},
-                    write: function(body) {
-                      bodyWritten= true;
-                      assert.isNotNull(body);
-                      assert.equal(4, body.length)
-                    }
-                  }
-                }
-              };
-            }
-            oa._request("PUT", "", {"Content-Type":"application/octet-stream"}, new Buffer([1,2,3,4]));
+            request.put = function(options, callback) {
+              assert.equal(options.headers["Content-Type"], "application/octet-stream");
+              callback(null, {statusCode: 200}, options.body);
+            };
+            oa._request("PUT", "", {"Content-Type":"application/octet-stream"}, new Buffer([1,2,3,4]), null, function(err, body){
+              bodyWritten= true;
+              assert.isNotNull(body);
+              assert.equal(4, body.length)
+            });
             assert.ok( bodyWritten );
           }
         }
@@ -238,7 +198,7 @@ vows.describe('OAuth2').addBatch({
           { 'User-Agent': '123Agent' }),
       'When calling get': {
         'we should see the User-Agent mixed into headers property in options passed to http-library' : function(oa) {
-          oa._executeRequest= function( http_library, options, callback ) {
+          request.get = function(options, callback){
             assert.equal(options.headers["User-Agent"], "123Agent");
           };
           oa.get("", {});
@@ -250,9 +210,9 @@ vows.describe('OAuth2').addBatch({
         undefined),
       'When calling get': {
         'we should see the default User-Agent mixed into headers property in options passed to http-library' : function(oa) {
-          oa._executeRequest= function( http_library, options, callback ) {
+          request.get = function(options, callback){
             assert.equal(options.headers["User-Agent"], "Node-oauth");
-            };
+          };
           oa.get("", {});
         }
       }


### PR DESCRIPTION
At Waffle.io, we're shipping an on-premises version that needs to support making requests through proxies.

By using [request/request](https://github.com/request/request) instead of the native `http` and `https` modules, proxies will be supported [using environment variables](https://github.com/request/request#controlling-proxy-behaviour-using-environment-variables).

I maintained the method signature for `_request`, for downstream API compatibility.

I only modified `oauth2`, I'll happily switch `oauth` to use [request/request](https://github.com/request/request) as well if you like.
