### PR TITLE
OAuth 1.0A Extra Parameters in Query String – Fixes signature mismatch.

### DIFF
--- a/lib/oauth.js
+++ b/lib/oauth.js
@@ -339,6 +339,15 @@ exports.OAuth.prototype._performSecureRequest= function( oauth_token, oauth_toke
     }
   }
 
+  if( method === "GET" && extra_params !== null ) {
+    parsedUrl.query = querystring.stringify(extra_params)
+                       .replace(/\!/g, "%21")
+                       .replace(/\'/g, "%27")
+                       .replace(/\(/g, "%28")
+                       .replace(/\)/g, "%29")
+                       .replace(/\*/g, "%2A");
+  }
+
   if( (method == "POST" || method == "PUT")  && ( post_body == null && extra_params != null) ) {
     // Fix the mismatch between the output of querystring.stringify() and this._encodeData()
     post_body= querystring.stringify(extra_params)


### PR DESCRIPTION
• Includes extra params as part of GET requests url query string.
• Fixes generated signature not matching the query string with passed extra params.

Useful in the context of applications that rely on parameters being passed in the query string (i.e. Xero API).