### PR TITLE
Update license attribute

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,9 +11,5 @@
 , "scripts": {
     "test": "make test"
   }
-, "licenses" :
-  [ { "type" : "MIT"
-    , "url" : "http://github.com/ciaranj/node-oauth/raw/master/LICENSE"
-    }
-  ]
+, "license" : "MIT"
 }


### PR DESCRIPTION
specifying the type and URL is deprecated:

https://docs.npmjs.com/files/package.json#license
http://npm1k.org/