### PR TITLE
Allow specification of arbitrary grant types

### DIFF
--- a/lib/oauth2.js
+++ b/lib/oauth2.js
@@ -163,7 +163,7 @@ exports.OAuth2.prototype.getOAuthAccessToken= function(code, params, callback) {
   var params= params || {};
   params['client_id'] = this._clientId;
   params['client_secret'] = this._clientSecret;
-  var codeParam = (params.grant_type === 'refresh_token') ? 'refresh_token' : 'code';
+  var codeParam = params.grant_type === undefined ? 'code' : params.grant_type;
   params[codeParam]= code;
 
   var post_data= querystring.stringify( params );

--- a/tests/oauth2.js
+++ b/tests/oauth2.js
@@ -68,14 +68,6 @@ vows.describe('OAuth2').addBatch({
           oa.getOAuthAccessToken("xsds23", {} );
         }
       },
-      'When an invalid grant_type parameter is specified': {
-        'we should pass the value of the code argument as the code parameter': function(oa) {
-          oa._request= function(method, url, headers, post_body, access_token, callback) {
-            assert.isTrue( post_body.indexOf("code=xsds23") != -1 );
-          };
-          oa.getOAuthAccessToken("xsds23", {grant_type:"refresh_toucan"} );
-        }
-      },
       'When a grant_type parameter of value "refresh_token" is specified': {
         'we should pass the value of the code argument as the refresh_token parameter, should pass a grant_type parameter, but shouldn\'t pass a code parameter' : function(oa) {
           oa._request= function(method, url, headers, post_body, access_token, callback) {


### PR DESCRIPTION
The OAuth 2 specification provides several standard grant_types:
- `authorization_code` per [Section 4.1.3](https://tools.ietf.org/html/rfc6749#section-4.1.3)
- `password` per [Section 4.3.2](https://tools.ietf.org/html/rfc6749#section-4.3.2)
- `client_credentials` per [Section 4.4.2](https://tools.ietf.org/html/rfc6749#section-4.4.2)
- `refresh_token` per [Section 6](https://tools.ietf.org/html/rfc6749#section-6)
- as well as allowing for custom grant types in [4.5](https://tools.ietf.org/html/rfc6749#section-4.5)

What's [the code](https://github.com/ciaranj/node-oauth/blob/master/lib/oauth2.js#L166-L167) currently either forces it to be `refresh_token` or `code`, which is not among any standard grant_type. Additionally, when an "invalid" grant type is passed, it sets the type to code rather than failing verbosely, which could result in undue confusion on behalf of the developer.

This PR modifies it so that, while `code` is still the default for backwards-compatibility, a `grant_type` passed in will be kept in the parameters.

If there is a desire to provide some stronger typing of the grant type, so to speak, I'd consider providing constants in node-oauth which can be passed in, in addition to allowing strings for custom grant types. E.g.

``` js
exports.GRANT = {
    CODE: 'authorization_code',
    PASSWORD: 'password',
    // ...
};
```
