### PR TITLE
Request timeout support

### DIFF
--- a/lib/oauth2.js
+++ b/lib/oauth2.js
@@ -5,7 +5,7 @@ var querystring= require('querystring'),
     URL= require('url'),
     OAuthUtils= require('./_utils');
 
-exports.OAuth2= function(clientId, clientSecret, baseSite, authorizePath, accessTokenPath, customHeaders) {
+exports.OAuth2= function(clientId, clientSecret, baseSite, authorizePath, accessTokenPath, customHeaders, clientOptions) {
   this._clientId= clientId;
   this._clientSecret= clientSecret;
   this._baseSite= baseSite;
@@ -15,6 +15,14 @@ exports.OAuth2= function(clientId, clientSecret, baseSite, authorizePath, access
   this._authMethod= "Bearer";
   this._customHeaders = customHeaders || {};
   this._useAuthorizationHeaderForGET= false;
+  this._clientOptions= this._defaultClientOptions= {
+    "requestTimeout": 0
+  };
+
+  if(clientOptions) {
+    this.setClientOptions(clientOptions)
+  }
+  
 }
 
 // This 'hack' method is required for sites that don't use
@@ -32,6 +40,21 @@ exports.OAuth2.prototype.setAuthMethod = function ( authMethod ) {
   this._authMethod = authMethod;
 };
 
+exports.OAuth2.prototype.setClientOptions= function(options) {
+  var key,
+    mergedOptions= {},
+    hasOwnProperty= Object.prototype.hasOwnProperty;
+
+  for( key in this._defaultClientOptions ) {
+    if( !hasOwnProperty.call(options, key) ) {
+      mergedOptions[key]= this._defaultClientOptions[key];
+    } else {
+      mergedOptions[key]= options[key];
+    }
+  }
+
+  this._clientOptions= mergedOptions;
+};
 
 // If you use the OAuth2 exposed 'get' method (and don't construct your own _request call )
 // this will specify whether to use an 'Authorize' header instead of passing the access_token as a query parameter
@@ -142,6 +165,15 @@ exports.OAuth2.prototype._executeRequest= function( http_library, options, post_
       passBackControl( response, result );
     });
   });
+
+  if(this._clientOptions.requestTimeout) {
+    request.setTimeout(this._clientOptions.requestTimeout, function () {
+      request.abort();
+      callbackCalled = true;
+      callback(new Error('E_OAUTH_REQUEST_TIMEOUT'));
+    });
+  }
+
   request.on('error', function(e) {
     callbackCalled= true;
     callback(e);


### PR DESCRIPTION
User is able to specify client's requestTimeout option. If set, request.setTimeout() is called on each request OAuth2 lib does.
If timeout event is triggered by the socket - Error("E_OAUTH_REQUEST_TIMEOUT") is thrown.