### PR TITLE
Ignore any errors from test requests

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
 , "author" : "Ciaran Jessup <ciaranj@gmail.com>"
 , "repository" : { "type":"git", "url":"http://github.com/ciaranj/node-oauth.git" }
 , "devDependencies": {
-    "vows": "0.5.x"
+    "vows": "^0.8.1"
   }
 , "scripts": {
     "test": "make test"

--- a/tests/oauthtests.js
+++ b/tests/oauthtests.js
@@ -333,6 +333,7 @@ vows.describe('OAuth').addBatch({
             var request= oa.post("http://foo.com/blah", "token", "token_secret", "BLAH", "text/plain")
             assert.isObject(request);
             assert.equal(request.method, "POST");
+            request.on("error", function (r) {});
             request.end();
           }
         },
@@ -525,6 +526,7 @@ vows.describe('OAuth').addBatch({
              var request= oa.get("http://foo.com/blah", "token", "token_secret")
              assert.isObject(request);
              assert.equal(request.method, "GET");
+             request.on("error", function (r) {});
              request.end();
            }
          },
@@ -557,6 +559,7 @@ vows.describe('OAuth').addBatch({
              var request= oa.put("http://foo.com/blah", "token", "token_secret", "BLAH", "text/plain")
              assert.isObject(request);
              assert.equal(request.method, "PUT");
+             request.on("error", function (r) {});
              request.end();
            }
          },
@@ -712,6 +715,7 @@ vows.describe('OAuth').addBatch({
              var request= oa.delete("http://foo.com/blah", "token", "token_secret")
              assert.isObject(request);
              assert.equal(request.method, "DELETE");
+             request.on("error", function (r) {});
              request.end();
            }
          },


### PR DESCRIPTION
Calling end causes the request to proceed, which may they lead to an exception being fired long after the test has seemingly completed if there is any kind of network problem.

These exceptions seem to get hidden by older versions of vows but newer ones manage to trap them and treat them as a failure.