### PR TITLE
Allow the empty string for oauth_token.

### DIFF
--- a/lib/oauth.js
+++ b/lib/oauth.js
@@ -265,7 +265,7 @@ exports.OAuth.prototype._prepareParameters= function( oauth_token, oauth_token_s
       "oauth_consumer_key":     this._consumerKey
   };
 
-  if( oauth_token ) {
+  if( oauth_token != null ) {
     oauthParameters["oauth_token"]= oauth_token;
   }
 


### PR DESCRIPTION
The oauth1 endpoint I am working with requires the oauth_token parameter to be present, even if it is an empty string. This change supports doing so by checking explicitly for not null.