### PR TITLE
Only set Content-Type header if there is a post body.

### DIFF
--- a/lib/oauth.js
+++ b/lib/oauth.js
@@ -355,11 +355,10 @@ exports.OAuth.prototype._performSecureRequest= function( oauth_token, oauth_toke
       } else {
           headers["Content-length"]= Buffer.byteLength(post_body);
       }
+    headers["Content-Type"]= post_content_type;
   } else {
       headers["Content-length"]= 0;
   }
-
-  headers["Content-Type"]= post_content_type;
 
   var path;
   if( !parsedUrl.pathname  || parsedUrl.pathname == "" ) parsedUrl.pathname ="/";


### PR DESCRIPTION
Currently, the HTTP Content-Type header is always present, even in GET requests where it is set to the default `application/x-www-form-urlencoded` value. When using this module with Jira, it will fail on GET requests with the error `HTTP Status 415 - Unsupported Media Type`.

This change only put the Content-Type header if there is actual data posted.