### PR TITLE
OAuth2 Authorization header for AuthAccessToken, POST support

### DIFF
--- a/lib/oauth2.js
+++ b/lib/oauth2.js
@@ -14,7 +14,9 @@ exports.OAuth2= function(clientId, clientSecret, baseSite, authorizePath, access
   this._accessTokenName= "access_token";
   this._authMethod= "Bearer";
   this._customHeaders = customHeaders || {};
+  this._useAuthorizationHeaderForAuth= false;
   this._useAuthorizationHeaderForGET= false;
+  this._useAuthorizationHeaderForPOST= false;
 }
 
 // This 'hack' method is required for sites that don't use
@@ -37,6 +39,18 @@ exports.OAuth2.prototype.setAuthMethod = function ( authMethod ) {
 // this will specify whether to use an 'Authorize' header instead of passing the access_token as a query parameter
 exports.OAuth2.prototype.useAuthorizationHeaderforGET = function(useIt) {
   this._useAuthorizationHeaderForGET= useIt;
+}
+
+// If you use the OAuth2 exposed 'get' method (and don't construct your own _request call )
+// this will specify whether to use an 'Authorize' header instead of passing the access_token as a query parameter
+exports.OAuth2.prototype.useAuthorizationHeaderforPOST = function(useIt) {
+  this._useAuthorizationHeaderForPOST= useIt;
+}
+
+// If you use the OAuth2 exposed 'getOAuthAccessToken' method (and don't construct your own _request call )
+// this will specify whether to use an 'Authorize' header instead of passing the access_token as a query parameter
+exports.OAuth2.prototype.useAuthorizationHeaderforAuth = function(useIt) {
+  this._useAuthorizationHeaderForAuth= useIt;
 }
 
 exports.OAuth2.prototype._getAccessTokenUrl= function() {
@@ -160,7 +174,13 @@ exports.OAuth2.prototype.getAuthorizeUrl= function( params ) {
   return this._baseSite + this._authorizeUrl + "?" + querystring.stringify(params);
 }
 
-exports.OAuth2.prototype.getOAuthAccessToken= function(code, params, callback) {
+exports.OAuth2.prototype.getOAuthAccessToken= function(code, params, access_token, callback) {
+
+  if(callback == undefined) {
+    callback = access_token;
+    access_token = null;
+  }
+
   var params= params || {};
   params['client_id'] = this._clientId;
   params['client_secret'] = this._clientSecret;
@@ -171,6 +191,11 @@ exports.OAuth2.prototype.getOAuthAccessToken= function(code, params, callback) {
   var post_headers= {
        'Content-Type': 'application/x-www-form-urlencoded'
    };
+
+   if( this._useAuthorizationHeaderForAuth ) {
+      post_headers['Authorization'] = this.buildAuthHeader(access_token);
+      access_token= null;
+  }
 
 
   this._request("POST", this._getAccessTokenUrl(), post_headers, post_data, null, function(error, data, response) {
@@ -211,4 +236,18 @@ exports.OAuth2.prototype.get= function(url, access_token, callback) {
     headers= {};
   }
   this._request("GET", url, headers, "", access_token, callback );
+}
+
+
+exports.OAuth2.prototype.post= function(url, access_token, data, callback) {
+  var headers = {
+    "Content-Type": "application/x-www-form-urlencoded"
+  };
+  if( this._useAuthorizationHeaderForPOST ) {
+    headers['Authorization'] = this.buildAuthHeader(access_token);
+    access_token= null;
+  }
+
+  var post_data = querystring.stringify(data);
+  this._request("POST", url, headers, post_data, access_token, callback );
 }


### PR DESCRIPTION
Hi,

I've added support to set the Authorization header for AuthAccessToken request, as it's necessary for Fitbit support. Also, I've added POST support to OAuth2.

Regards,
Daniel