### PR TITLE
Accept application/json access_token responses

### DIFF
--- a/lib/oauth2.js
+++ b/lib/oauth2.js
@@ -169,7 +169,8 @@ exports.OAuth2.prototype.getOAuthAccessToken= function(code, params, callback) {
 
   var post_data= querystring.stringify( params );
   var post_headers= {
-       'Content-Type': 'application/x-www-form-urlencoded'
+       'Content-Type': 'application/x-www-form-urlencoded',
+       'Accept': 'application/json'
    };
 
 
@@ -183,9 +184,9 @@ exports.OAuth2.prototype.getOAuthAccessToken= function(code, params, callback) {
         results= JSON.parse( data );
       }
       catch(e) {
-        // .... However both Facebook + Github currently use rev05 of the spec
-        // and neither seem to specify a content-type correctly in their response headers :(
-        // clients of these services will suffer a *minor* performance cost of the exception
+        // .... However Facebook currently uses rev05 of the spec
+        // and doesn't specify a content-type correctly in their response headers :(
+        // Facebook clients will suffer a *minor* performance cost of the exception
         // being thrown
         results= querystring.parse( data );
       }

--- a/tests/oauth2tests.js
+++ b/tests/oauth2tests.js
@@ -37,6 +37,14 @@ vows.describe('OAuth2').addBatch({
           assert.ok(callbackCalled);
         }
       },
+      'When handling the access token request': {
+        'we should accept application/json': function(oa) {
+          oa._request= function(method, url, headers, post_body, access_token, callback) {
+            assert.equal( headers["Accept"], "application/json" );
+          };
+          oa.getOAuthAccessToken("", {});
+        }
+      },
       'When handling the access token response': {
         'we should correctly extract the token if received as form-data': function (oa) {
             oa._request= function( method, url, fo, bar, bleh, callback) {


### PR DESCRIPTION
I'm not sure about Facebook but Github will now give you a correct JSON response if you explicitly ask for one by specifying the `Accept: application/json` header (https://developer.github.com/v3/oauth/#response).

I can't claim to know much about oauth2 so this may be bad/against the spec but I tested it on my project and it worked fine, plus the tests are passing. 
