### PR TITLE
Accept GET content_type

### DIFF
--- a/lib/oauth.js
+++ b/lib/oauth.js
@@ -483,8 +483,11 @@ exports.OAuth.prototype.delete= function(url, oauth_token, oauth_token_secret, c
   return this._performSecureRequest( oauth_token, oauth_token_secret, "DELETE", url, null, "", null, callback );
 }
 
-exports.OAuth.prototype.get= function(url, oauth_token, oauth_token_secret, callback) {
-  return this._performSecureRequest( oauth_token, oauth_token_secret, "GET", url, null, "", null, callback );
+exports.OAuth.prototype.get= function(url, oauth_token, oauth_token_secret, get_content_type, callback) {
+  if (typeof get_content_type == "function") {
+    callback= get_content_type;
+  }
+  return this._performSecureRequest( oauth_token, oauth_token_secret, "GET", url, null, "", get_content_type, callback );
 }
 
 exports.OAuth.prototype._putOrPost= function(method, url, oauth_token, oauth_token_secret, post_body, post_content_type, callback) {


### PR DESCRIPTION
Added content-type in get method to allow users to put a custom header content-type.
Many sites require a custom header in oauth authentication (via GET).