### PR TITLE
Make the "access_token" part of the signature base string if it is em…

### DIFF
--- a/lib/oauth.js
+++ b/lib/oauth.js
@@ -265,7 +265,7 @@ exports.OAuth.prototype._prepareParameters= function( oauth_token, oauth_token_s
       "oauth_consumer_key":     this._consumerKey
   };
 
-  if( oauth_token ) {
+  if( oauth_token != undefined ) {
     oauthParameters["oauth_token"]= oauth_token;
   }
 


### PR DESCRIPTION
…pty string.

In case the access token is empty string rather than null, some of the OAuth utils have it included in the signature base string. see computeSignature method at:
http://grepcode.com/file/repo1.maven.org/maven2/com.google.api.client/google-api-client/1.4.1-beta/com/google/api/client/auth/oauth/OAuthParameters.java#OAuthParameters.computeSignature%28java.lang.String%2Ccom.google.api.client.http.GenericUrl%29
