### PR TITLE
Add url auth support

### DIFF
--- a/lib/oauth2.js
+++ b/lib/oauth2.js
@@ -101,6 +101,7 @@ exports.OAuth2.prototype._request= function(method, url, headers, post_body, acc
   var queryStr= querystring.stringify(parsedUrl.query);
   if( queryStr ) queryStr=  "?" + queryStr;
   var options = {
+    auth: parsedUrl.auth,
     host:parsedUrl.hostname,
     port: parsedUrl.port,
     path: parsedUrl.pathname + queryStr,


### PR DESCRIPTION
Currently, the url is parsed which is great but it's missing the auth piece.

For example, the current code base strips the user/password from the url like so, https://user:password@www.myserver.com/oauth/token

This pull request will parse the user/password properly when the request is made.