### PR TITLE
Promises Support

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,674 @@
+                    GNU GENERAL PUBLIC LICENSE
+                       Version 3, 29 June 2007
+
+ Copyright (C) 2007 Free Software Foundation, Inc. <http://fsf.org/>
+ Everyone is permitted to copy and distribute verbatim copies
+ of this license document, but changing it is not allowed.
+
+                            Preamble
+
+  The GNU General Public License is a free, copyleft license for
+software and other kinds of works.
+
+  The licenses for most software and other practical works are designed
+to take away your freedom to share and change the works.  By contrast,
+the GNU General Public License is intended to guarantee your freedom to
+share and change all versions of a program--to make sure it remains free
+software for all its users.  We, the Free Software Foundation, use the
+GNU General Public License for most of our software; it applies also to
+any other work released this way by its authors.  You can apply it to
+your programs, too.
+
+  When we speak of free software, we are referring to freedom, not
+price.  Our General Public Licenses are designed to make sure that you
+have the freedom to distribute copies of free software (and charge for
+them if you wish), that you receive source code or can get it if you
+want it, that you can change the software or use pieces of it in new
+free programs, and that you know you can do these things.
+
+  To protect your rights, we need to prevent others from denying you
+these rights or asking you to surrender the rights.  Therefore, you have
+certain responsibilities if you distribute copies of the software, or if
+you modify it: responsibilities to respect the freedom of others.
+
+  For example, if you distribute copies of such a program, whether
+gratis or for a fee, you must pass on to the recipients the same
+freedoms that you received.  You must make sure that they, too, receive
+or can get the source code.  And you must show them these terms so they
+know their rights.
+
+  Developers that use the GNU GPL protect your rights with two steps:
+(1) assert copyright on the software, and (2) offer you this License
+giving you legal permission to copy, distribute and/or modify it.
+
+  For the developers' and authors' protection, the GPL clearly explains
+that there is no warranty for this free software.  For both users' and
+authors' sake, the GPL requires that modified versions be marked as
+changed, so that their problems will not be attributed erroneously to
+authors of previous versions.
+
+  Some devices are designed to deny users access to install or run
+modified versions of the software inside them, although the manufacturer
+can do so.  This is fundamentally incompatible with the aim of
+protecting users' freedom to change the software.  The systematic
+pattern of such abuse occurs in the area of products for individuals to
+use, which is precisely where it is most unacceptable.  Therefore, we
+have designed this version of the GPL to prohibit the practice for those
+products.  If such problems arise substantially in other domains, we
+stand ready to extend this provision to those domains in future versions
+of the GPL, as needed to protect the freedom of users.
+
+  Finally, every program is threatened constantly by software patents.
+States should not allow patents to restrict development and use of
+software on general-purpose computers, but in those that do, we wish to
+avoid the special danger that patents applied to a free program could
+make it effectively proprietary.  To prevent this, the GPL assures that
+patents cannot be used to render the program non-free.
+
+  The precise terms and conditions for copying, distribution and
+modification follow.
+
+                       TERMS AND CONDITIONS
+
+  0. Definitions.
+
+  "This License" refers to version 3 of the GNU General Public License.
+
+  "Copyright" also means copyright-like laws that apply to other kinds of
+works, such as semiconductor masks.
+
+  "The Program" refers to any copyrightable work licensed under this
+License.  Each licensee is addressed as "you".  "Licensees" and
+"recipients" may be individuals or organizations.
+
+  To "modify" a work means to copy from or adapt all or part of the work
+in a fashion requiring copyright permission, other than the making of an
+exact copy.  The resulting work is called a "modified version" of the
+earlier work or a work "based on" the earlier work.
+
+  A "covered work" means either the unmodified Program or a work based
+on the Program.
+
+  To "propagate" a work means to do anything with it that, without
+permission, would make you directly or secondarily liable for
+infringement under applicable copyright law, except executing it on a
+computer or modifying a private copy.  Propagation includes copying,
+distribution (with or without modification), making available to the
+public, and in some countries other activities as well.
+
+  To "convey" a work means any kind of propagation that enables other
+parties to make or receive copies.  Mere interaction with a user through
+a computer network, with no transfer of a copy, is not conveying.
+
+  An interactive user interface displays "Appropriate Legal Notices"
+to the extent that it includes a convenient and prominently visible
+feature that (1) displays an appropriate copyright notice, and (2)
+tells the user that there is no warranty for the work (except to the
+extent that warranties are provided), that licensees may convey the
+work under this License, and how to view a copy of this License.  If
+the interface presents a list of user commands or options, such as a
+menu, a prominent item in the list meets this criterion.
+
+  1. Source Code.
+
+  The "source code" for a work means the preferred form of the work
+for making modifications to it.  "Object code" means any non-source
+form of a work.
+
+  A "Standard Interface" means an interface that either is an official
+standard defined by a recognized standards body, or, in the case of
+interfaces specified for a particular programming language, one that
+is widely used among developers working in that language.
+
+  The "System Libraries" of an executable work include anything, other
+than the work as a whole, that (a) is included in the normal form of
+packaging a Major Component, but which is not part of that Major
+Component, and (b) serves only to enable use of the work with that
+Major Component, or to implement a Standard Interface for which an
+implementation is available to the public in source code form.  A
+"Major Component", in this context, means a major essential component
+(kernel, window system, and so on) of the specific operating system
+(if any) on which the executable work runs, or a compiler used to
+produce the work, or an object code interpreter used to run it.
+
+  The "Corresponding Source" for a work in object code form means all
+the source code needed to generate, install, and (for an executable
+work) run the object code and to modify the work, including scripts to
+control those activities.  However, it does not include the work's
+System Libraries, or general-purpose tools or generally available free
+programs which are used unmodified in performing those activities but
+which are not part of the work.  For example, Corresponding Source
+includes interface definition files associated with source files for
+the work, and the source code for shared libraries and dynamically
+linked subprograms that the work is specifically designed to require,
+such as by intimate data communication or control flow between those
+subprograms and other parts of the work.
+
+  The Corresponding Source need not include anything that users
+can regenerate automatically from other parts of the Corresponding
+Source.
+
+  The Corresponding Source for a work in source code form is that
+same work.
+
+  2. Basic Permissions.
+
+  All rights granted under this License are granted for the term of
+copyright on the Program, and are irrevocable provided the stated
+conditions are met.  This License explicitly affirms your unlimited
+permission to run the unmodified Program.  The output from running a
+covered work is covered by this License only if the output, given its
+content, constitutes a covered work.  This License acknowledges your
+rights of fair use or other equivalent, as provided by copyright law.
+
+  You may make, run and propagate covered works that you do not
+convey, without conditions so long as your license otherwise remains
+in force.  You may convey covered works to others for the sole purpose
+of having them make modifications exclusively for you, or provide you
+with facilities for running those works, provided that you comply with
+the terms of this License in conveying all material for which you do
+not control copyright.  Those thus making or running the covered works
+for you must do so exclusively on your behalf, under your direction
+and control, on terms that prohibit them from making any copies of
+your copyrighted material outside their relationship with you.
+
+  Conveying under any other circumstances is permitted solely under
+the conditions stated below.  Sublicensing is not allowed; section 10
+makes it unnecessary.
+
+  3. Protecting Users' Legal Rights From Anti-Circumvention Law.
+
+  No covered work shall be deemed part of an effective technological
+measure under any applicable law fulfilling obligations under article
+11 of the WIPO copyright treaty adopted on 20 December 1996, or
+similar laws prohibiting or restricting circumvention of such
+measures.
+
+  When you convey a covered work, you waive any legal power to forbid
+circumvention of technological measures to the extent such circumvention
+is effected by exercising rights under this License with respect to
+the covered work, and you disclaim any intention to limit operation or
+modification of the work as a means of enforcing, against the work's
+users, your or third parties' legal rights to forbid circumvention of
+technological measures.
+
+  4. Conveying Verbatim Copies.
+
+  You may convey verbatim copies of the Program's source code as you
+receive it, in any medium, provided that you conspicuously and
+appropriately publish on each copy an appropriate copyright notice;
+keep intact all notices stating that this License and any
+non-permissive terms added in accord with section 7 apply to the code;
+keep intact all notices of the absence of any warranty; and give all
+recipients a copy of this License along with the Program.
+
+  You may charge any price or no price for each copy that you convey,
+and you may offer support or warranty protection for a fee.
+
+  5. Conveying Modified Source Versions.
+
+  You may convey a work based on the Program, or the modifications to
+produce it from the Program, in the form of source code under the
+terms of section 4, provided that you also meet all of these conditions:
+
+    a) The work must carry prominent notices stating that you modified
+    it, and giving a relevant date.
+
+    b) The work must carry prominent notices stating that it is
+    released under this License and any conditions added under section
+    7.  This requirement modifies the requirement in section 4 to
+    "keep intact all notices".
+
+    c) You must license the entire work, as a whole, under this
+    License to anyone who comes into possession of a copy.  This
+    License will therefore apply, along with any applicable section 7
+    additional terms, to the whole of the work, and all its parts,
+    regardless of how they are packaged.  This License gives no
+    permission to license the work in any other way, but it does not
+    invalidate such permission if you have separately received it.
+
+    d) If the work has interactive user interfaces, each must display
+    Appropriate Legal Notices; however, if the Program has interactive
+    interfaces that do not display Appropriate Legal Notices, your
+    work need not make them do so.
+
+  A compilation of a covered work with other separate and independent
+works, which are not by their nature extensions of the covered work,
+and which are not combined with it such as to form a larger program,
+in or on a volume of a storage or distribution medium, is called an
+"aggregate" if the compilation and its resulting copyright are not
+used to limit the access or legal rights of the compilation's users
+beyond what the individual works permit.  Inclusion of a covered work
+in an aggregate does not cause this License to apply to the other
+parts of the aggregate.
+
+  6. Conveying Non-Source Forms.
+
+  You may convey a covered work in object code form under the terms
+of sections 4 and 5, provided that you also convey the
+machine-readable Corresponding Source under the terms of this License,
+in one of these ways:
+
+    a) Convey the object code in, or embodied in, a physical product
+    (including a physical distribution medium), accompanied by the
+    Corresponding Source fixed on a durable physical medium
+    customarily used for software interchange.
+
+    b) Convey the object code in, or embodied in, a physical product
+    (including a physical distribution medium), accompanied by a
+    written offer, valid for at least three years and valid for as
+    long as you offer spare parts or customer support for that product
+    model, to give anyone who possesses the object code either (1) a
+    copy of the Corresponding Source for all the software in the
+    product that is covered by this License, on a durable physical
+    medium customarily used for software interchange, for a price no
+    more than your reasonable cost of physically performing this
+    conveying of source, or (2) access to copy the
+    Corresponding Source from a network server at no charge.
+
+    c) Convey individual copies of the object code with a copy of the
+    written offer to provide the Corresponding Source.  This
+    alternative is allowed only occasionally and noncommercially, and
+    only if you received the object code with such an offer, in accord
+    with subsection 6b.
+
+    d) Convey the object code by offering access from a designated
+    place (gratis or for a charge), and offer equivalent access to the
+    Corresponding Source in the same way through the same place at no
+    further charge.  You need not require recipients to copy the
+    Corresponding Source along with the object code.  If the place to
+    copy the object code is a network server, the Corresponding Source
+    may be on a different server (operated by you or a third party)
+    that supports equivalent copying facilities, provided you maintain
+    clear directions next to the object code saying where to find the
+    Corresponding Source.  Regardless of what server hosts the
+    Corresponding Source, you remain obligated to ensure that it is
+    available for as long as needed to satisfy these requirements.
+
+    e) Convey the object code using peer-to-peer transmission, provided
+    you inform other peers where the object code and Corresponding
+    Source of the work are being offered to the general public at no
+    charge under subsection 6d.
+
+  A separable portion of the object code, whose source code is excluded
+from the Corresponding Source as a System Library, need not be
+included in conveying the object code work.
+
+  A "User Product" is either (1) a "consumer product", which means any
+tangible personal property which is normally used for personal, family,
+or household purposes, or (2) anything designed or sold for incorporation
+into a dwelling.  In determining whether a product is a consumer product,
+doubtful cases shall be resolved in favor of coverage.  For a particular
+product received by a particular user, "normally used" refers to a
+typical or common use of that class of product, regardless of the status
+of the particular user or of the way in which the particular user
+actually uses, or expects or is expected to use, the product.  A product
+is a consumer product regardless of whether the product has substantial
+commercial, industrial or non-consumer uses, unless such uses represent
+the only significant mode of use of the product.
+
+  "Installation Information" for a User Product means any methods,
+procedures, authorization keys, or other information required to install
+and execute modified versions of a covered work in that User Product from
+a modified version of its Corresponding Source.  The information must
+suffice to ensure that the continued functioning of the modified object
+code is in no case prevented or interfered with solely because
+modification has been made.
+
+  If you convey an object code work under this section in, or with, or
+specifically for use in, a User Product, and the conveying occurs as
+part of a transaction in which the right of possession and use of the
+User Product is transferred to the recipient in perpetuity or for a
+fixed term (regardless of how the transaction is characterized), the
+Corresponding Source conveyed under this section must be accompanied
+by the Installation Information.  But this requirement does not apply
+if neither you nor any third party retains the ability to install
+modified object code on the User Product (for example, the work has
+been installed in ROM).
+
+  The requirement to provide Installation Information does not include a
+requirement to continue to provide support service, warranty, or updates
+for a work that has been modified or installed by the recipient, or for
+the User Product in which it has been modified or installed.  Access to a
+network may be denied when the modification itself materially and
+adversely affects the operation of the network or violates the rules and
+protocols for communication across the network.
+
+  Corresponding Source conveyed, and Installation Information provided,
+in accord with this section must be in a format that is publicly
+documented (and with an implementation available to the public in
+source code form), and must require no special password or key for
+unpacking, reading or copying.
+
+  7. Additional Terms.
+
+  "Additional permissions" are terms that supplement the terms of this
+License by making exceptions from one or more of its conditions.
+Additional permissions that are applicable to the entire Program shall
+be treated as though they were included in this License, to the extent
+that they are valid under applicable law.  If additional permissions
+apply only to part of the Program, that part may be used separately
+under those permissions, but the entire Program remains governed by
+this License without regard to the additional permissions.
+
+  When you convey a copy of a covered work, you may at your option
+remove any additional permissions from that copy, or from any part of
+it.  (Additional permissions may be written to require their own
+removal in certain cases when you modify the work.)  You may place
+additional permissions on material, added by you to a covered work,
+for which you have or can give appropriate copyright permission.
+
+  Notwithstanding any other provision of this License, for material you
+add to a covered work, you may (if authorized by the copyright holders of
+that material) supplement the terms of this License with terms:
+
+    a) Disclaiming warranty or limiting liability differently from the
+    terms of sections 15 and 16 of this License; or
+
+    b) Requiring preservation of specified reasonable legal notices or
+    author attributions in that material or in the Appropriate Legal
+    Notices displayed by works containing it; or
+
+    c) Prohibiting misrepresentation of the origin of that material, or
+    requiring that modified versions of such material be marked in
+    reasonable ways as different from the original version; or
+
+    d) Limiting the use for publicity purposes of names of licensors or
+    authors of the material; or
+
+    e) Declining to grant rights under trademark law for use of some
+    trade names, trademarks, or service marks; or
+
+    f) Requiring indemnification of licensors and authors of that
+    material by anyone who conveys the material (or modified versions of
+    it) with contractual assumptions of liability to the recipient, for
+    any liability that these contractual assumptions directly impose on
+    those licensors and authors.
+
+  All other non-permissive additional terms are considered "further
+restrictions" within the meaning of section 10.  If the Program as you
+received it, or any part of it, contains a notice stating that it is
+governed by this License along with a term that is a further
+restriction, you may remove that term.  If a license document contains
+a further restriction but permits relicensing or conveying under this
+License, you may add to a covered work material governed by the terms
+of that license document, provided that the further restriction does
+not survive such relicensing or conveying.
+
+  If you add terms to a covered work in accord with this section, you
+must place, in the relevant source files, a statement of the
+additional terms that apply to those files, or a notice indicating
+where to find the applicable terms.
+
+  Additional terms, permissive or non-permissive, may be stated in the
+form of a separately written license, or stated as exceptions;
+the above requirements apply either way.
+
+  8. Termination.
+
+  You may not propagate or modify a covered work except as expressly
+provided under this License.  Any attempt otherwise to propagate or
+modify it is void, and will automatically terminate your rights under
+this License (including any patent licenses granted under the third
+paragraph of section 11).
+
+  However, if you cease all violation of this License, then your
+license from a particular copyright holder is reinstated (a)
+provisionally, unless and until the copyright holder explicitly and
+finally terminates your license, and (b) permanently, if the copyright
+holder fails to notify you of the violation by some reasonable means
+prior to 60 days after the cessation.
+
+  Moreover, your license from a particular copyright holder is
+reinstated permanently if the copyright holder notifies you of the
+violation by some reasonable means, this is the first time you have
+received notice of violation of this License (for any work) from that
+copyright holder, and you cure the violation prior to 30 days after
+your receipt of the notice.
+
+  Termination of your rights under this section does not terminate the
+licenses of parties who have received copies or rights from you under
+this License.  If your rights have been terminated and not permanently
+reinstated, you do not qualify to receive new licenses for the same
+material under section 10.
+
+  9. Acceptance Not Required for Having Copies.
+
+  You are not required to accept this License in order to receive or
+run a copy of the Program.  Ancillary propagation of a covered work
+occurring solely as a consequence of using peer-to-peer transmission
+to receive a copy likewise does not require acceptance.  However,
+nothing other than this License grants you permission to propagate or
+modify any covered work.  These actions infringe copyright if you do
+not accept this License.  Therefore, by modifying or propagating a
+covered work, you indicate your acceptance of this License to do so.
+
+  10. Automatic Licensing of Downstream Recipients.
+
+  Each time you convey a covered work, the recipient automatically
+receives a license from the original licensors, to run, modify and
+propagate that work, subject to this License.  You are not responsible
+for enforcing compliance by third parties with this License.
+
+  An "entity transaction" is a transaction transferring control of an
+organization, or substantially all assets of one, or subdividing an
+organization, or merging organizations.  If propagation of a covered
+work results from an entity transaction, each party to that
+transaction who receives a copy of the work also receives whatever
+licenses to the work the party's predecessor in interest had or could
+give under the previous paragraph, plus a right to possession of the
+Corresponding Source of the work from the predecessor in interest, if
+the predecessor has it or can get it with reasonable efforts.
+
+  You may not impose any further restrictions on the exercise of the
+rights granted or affirmed under this License.  For example, you may
+not impose a license fee, royalty, or other charge for exercise of
+rights granted under this License, and you may not initiate litigation
+(including a cross-claim or counterclaim in a lawsuit) alleging that
+any patent claim is infringed by making, using, selling, offering for
+sale, or importing the Program or any portion of it.
+
+  11. Patents.
+
+  A "contributor" is a copyright holder who authorizes use under this
+License of the Program or a work on which the Program is based.  The
+work thus licensed is called the contributor's "contributor version".
+
+  A contributor's "essential patent claims" are all patent claims
+owned or controlled by the contributor, whether already acquired or
+hereafter acquired, that would be infringed by some manner, permitted
+by this License, of making, using, or selling its contributor version,
+but do not include claims that would be infringed only as a
+consequence of further modification of the contributor version.  For
+purposes of this definition, "control" includes the right to grant
+patent sublicenses in a manner consistent with the requirements of
+this License.
+
+  Each contributor grants you a non-exclusive, worldwide, royalty-free
+patent license under the contributor's essential patent claims, to
+make, use, sell, offer for sale, import and otherwise run, modify and
+propagate the contents of its contributor version.
+
+  In the following three paragraphs, a "patent license" is any express
+agreement or commitment, however denominated, not to enforce a patent
+(such as an express permission to practice a patent or covenant not to
+sue for patent infringement).  To "grant" such a patent license to a
+party means to make such an agreement or commitment not to enforce a
+patent against the party.
+
+  If you convey a covered work, knowingly relying on a patent license,
+and the Corresponding Source of the work is not available for anyone
+to copy, free of charge and under the terms of this License, through a
+publicly available network server or other readily accessible means,
+then you must either (1) cause the Corresponding Source to be so
+available, or (2) arrange to deprive yourself of the benefit of the
+patent license for this particular work, or (3) arrange, in a manner
+consistent with the requirements of this License, to extend the patent
+license to downstream recipients.  "Knowingly relying" means you have
+actual knowledge that, but for the patent license, your conveying the
+covered work in a country, or your recipient's use of the covered work
+in a country, would infringe one or more identifiable patents in that
+country that you have reason to believe are valid.
+
+  If, pursuant to or in connection with a single transaction or
+arrangement, you convey, or propagate by procuring conveyance of, a
+covered work, and grant a patent license to some of the parties
+receiving the covered work authorizing them to use, propagate, modify
+or convey a specific copy of the covered work, then the patent license
+you grant is automatically extended to all recipients of the covered
+work and works based on it.
+
+  A patent license is "discriminatory" if it does not include within
+the scope of its coverage, prohibits the exercise of, or is
+conditioned on the non-exercise of one or more of the rights that are
+specifically granted under this License.  You may not convey a covered
+work if you are a party to an arrangement with a third party that is
+in the business of distributing software, under which you make payment
+to the third party based on the extent of your activity of conveying
+the work, and under which the third party grants, to any of the
+parties who would receive the covered work from you, a discriminatory
+patent license (a) in connection with copies of the covered work
+conveyed by you (or copies made from those copies), or (b) primarily
+for and in connection with specific products or compilations that
+contain the covered work, unless you entered into that arrangement,
+or that patent license was granted, prior to 28 March 2007.
+
+  Nothing in this License shall be construed as excluding or limiting
+any implied license or other defenses to infringement that may
+otherwise be available to you under applicable patent law.
+
+  12. No Surrender of Others' Freedom.
+
+  If conditions are imposed on you (whether by court order, agreement or
+otherwise) that contradict the conditions of this License, they do not
+excuse you from the conditions of this License.  If you cannot convey a
+covered work so as to satisfy simultaneously your obligations under this
+License and any other pertinent obligations, then as a consequence you may
+not convey it at all.  For example, if you agree to terms that obligate you
+to collect a royalty for further conveying from those to whom you convey
+the Program, the only way you could satisfy both those terms and this
+License would be to refrain entirely from conveying the Program.
+
+  13. Use with the GNU Affero General Public License.
+
+  Notwithstanding any other provision of this License, you have
+permission to link or combine any covered work with a work licensed
+under version 3 of the GNU Affero General Public License into a single
+combined work, and to convey the resulting work.  The terms of this
+License will continue to apply to the part which is the covered work,
+but the special requirements of the GNU Affero General Public License,
+section 13, concerning interaction through a network will apply to the
+combination as such.
+
+  14. Revised Versions of this License.
+
+  The Free Software Foundation may publish revised and/or new versions of
+the GNU General Public License from time to time.  Such new versions will
+be similar in spirit to the present version, but may differ in detail to
+address new problems or concerns.
+
+  Each version is given a distinguishing version number.  If the
+Program specifies that a certain numbered version of the GNU General
+Public License "or any later version" applies to it, you have the
+option of following the terms and conditions either of that numbered
+version or of any later version published by the Free Software
+Foundation.  If the Program does not specify a version number of the
+GNU General Public License, you may choose any version ever published
+by the Free Software Foundation.
+
+  If the Program specifies that a proxy can decide which future
+versions of the GNU General Public License can be used, that proxy's
+public statement of acceptance of a version permanently authorizes you
+to choose that version for the Program.
+
+  Later license versions may give you additional or different
+permissions.  However, no additional obligations are imposed on any
+author or copyright holder as a result of your choosing to follow a
+later version.
+
+  15. Disclaimer of Warranty.
+
+  THERE IS NO WARRANTY FOR THE PROGRAM, TO THE EXTENT PERMITTED BY
+APPLICABLE LAW.  EXCEPT WHEN OTHERWISE STATED IN WRITING THE COPYRIGHT
+HOLDERS AND/OR OTHER PARTIES PROVIDE THE PROGRAM "AS IS" WITHOUT WARRANTY
+OF ANY KIND, EITHER EXPRESSED OR IMPLIED, INCLUDING, BUT NOT LIMITED TO,
+THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+PURPOSE.  THE ENTIRE RISK AS TO THE QUALITY AND PERFORMANCE OF THE PROGRAM
+IS WITH YOU.  SHOULD THE PROGRAM PROVE DEFECTIVE, YOU ASSUME THE COST OF
+ALL NECESSARY SERVICING, REPAIR OR CORRECTION.
+
+  16. Limitation of Liability.
+
+  IN NO EVENT UNLESS REQUIRED BY APPLICABLE LAW OR AGREED TO IN WRITING
+WILL ANY COPYRIGHT HOLDER, OR ANY OTHER PARTY WHO MODIFIES AND/OR CONVEYS
+THE PROGRAM AS PERMITTED ABOVE, BE LIABLE TO YOU FOR DAMAGES, INCLUDING ANY
+GENERAL, SPECIAL, INCIDENTAL OR CONSEQUENTIAL DAMAGES ARISING OUT OF THE
+USE OR INABILITY TO USE THE PROGRAM (INCLUDING BUT NOT LIMITED TO LOSS OF
+DATA OR DATA BEING RENDERED INACCURATE OR LOSSES SUSTAINED BY YOU OR THIRD
+PARTIES OR A FAILURE OF THE PROGRAM TO OPERATE WITH ANY OTHER PROGRAMS),
+EVEN IF SUCH HOLDER OR OTHER PARTY HAS BEEN ADVISED OF THE POSSIBILITY OF
+SUCH DAMAGES.
+
+  17. Interpretation of Sections 15 and 16.
+
+  If the disclaimer of warranty and limitation of liability provided
+above cannot be given local legal effect according to their terms,
+reviewing courts shall apply local law that most closely approximates
+an absolute waiver of all civil liability in connection with the
+Program, unless a warranty or assumption of liability accompanies a
+copy of the Program in return for a fee.
+
+                     END OF TERMS AND CONDITIONS
+
+            How to Apply These Terms to Your New Programs
+
+  If you develop a new program, and you want it to be of the greatest
+possible use to the public, the best way to achieve this is to make it
+free software which everyone can redistribute and change under these terms.
+
+  To do so, attach the following notices to the program.  It is safest
+to attach them to the start of each source file to most effectively
+state the exclusion of warranty; and each file should have at least
+the "copyright" line and a pointer to where the full notice is found.
+
+    <one line to give the program's name and a brief idea of what it does.>
+    Copyright (C) <year>  <name of author>
+
+    This program is free software: you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    This program is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+Also add information on how to contact you by electronic and paper mail.
+
+  If the program does terminal interaction, make it output a short
+notice like this when it starts in an interactive mode:
+
+    <program>  Copyright (C) <year>  <name of author>
+    This program comes with ABSOLUTELY NO WARRANTY; for details type `show w'.
+    This is free software, and you are welcome to redistribute it
+    under certain conditions; type `show c' for details.
+
+The hypothetical commands `show w' and `show c' should show the appropriate
+parts of the General Public License.  Of course, your program's commands
+might be different; for a GUI interface, you would use an "about box".
+
+  You should also get your employer (if you work as a programmer) or school,
+if any, to sign a "copyright disclaimer" for the program, if necessary.
+For more information on this, and how to apply and follow the GNU GPL, see
+<http://www.gnu.org/licenses/>.
+
+  The GNU General Public License does not permit incorporating your program
+into proprietary programs.  If your program is a subroutine library, you
+may consider it more useful to permit linking proprietary applications with
+the library.  If this is what you want to do, use the GNU Lesser General
+Public License instead of this License.  But first, please read
+<http://www.gnu.org/philosophy/why-not-lgpl.html>.

--- a/LICENSE
+++ b/LICENSE
@@ -1,8 +1,0 @@
-The MIT License (MIT)
-Copyright (c) <2010-2012> <Ciaran Jessup>
-
-Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
-
-The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
-
-THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.

--- a/LICENSE.mit
+++ b/LICENSE.mit
@@ -1,0 +1,17 @@
+The MIT License (MIT)
+Copyright (c) <2010-2012> <Ciaran Jessup>
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of this software
+and associated documentation files (the "Software"), to deal in the Software without restriction,
+including without limitation the rights to use, copy, modify, merge, publish, distribute,
+sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all copies or
+substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT
+NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
+DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.

--- a/Readme.md
+++ b/Readme.md
@@ -15,7 +15,7 @@ If you go to the original project and modify the code there, your changes will b
 
 # Installation
 
-    $ npm install oauth
+    npm install oauth-libre
 
 
 # Examples

--- a/Readme.md
+++ b/Readme.md
@@ -52,8 +52,43 @@ describe('OAuth1.0',function(){
 ```
 
 ## OAuth2.0 
+
+### Usage
+
 ```javascript
-describe('OAuth2',function(){
+var OAuth2 = require('oauth').OAuth2;
+
+console.log("Login here to get an authorization code: " + oauth2.getAuthorizeUrl());
+
+var oauth2 = new OAuth2(
+  "client_id", // client id
+  "client_secret", // client secret
+  "http://localhost:3000/", // base site url
+  null, // authorize path
+  "/oauth/token", // access token path
+  null // custom headers object
+);
+
+oauth2.getOAuthAccessToken(
+  "auth_code",
+  {
+    "grant_type": "authorization_code",
+    "redirect_uri": "http://example.com/redirect_uri"
+  },
+  function(error, accessToken, refreshToken, results) {
+    if (error) {
+      console.log("Error: " + error);
+    } else {
+      console.log("Results: " + results);
+    }
+  }
+);
+```
+
+### Test
+
+```javascript
+describe('OAuth2',function() {
   var OAuth = require('oauth');
 
    it('gets bearer token', function(done){

--- a/Readme.md
+++ b/Readme.md
@@ -1,24 +1,24 @@
-node-oauth
-===========
+# node-oauth
 A simple oauth API for node.js .  This API allows users to authenticate against OAUTH providers, and thus act as OAuth consumers. It also has support for OAuth Echo, which is used for communicating with 3rd party media providers such as TwitPic and yFrog.
 
 Tested against Twitter (http://twitter.com), term.ie (http://term.ie/oauth/example/), TwitPic, and Yahoo!
 
 Also provides rudimentary OAuth2 support, tested against facebook, github, foursquare, google and Janrain.   For more complete usage examples please take a look at connect-auth (http://github.com/ciaranj/connect-auth)
 
-[![Clone in Koding](http://learn.koding.com/btn/clone_d.png)][koding]
-[koding]: https://koding.com/Teamwork?import=https://github.com/ciaranj/node-oauth/archive/master.zip&c=git1
-[![Pair on Thinkful](https://tf-assets-staging.s3.amazonaws.com/badges/thinkful_repo_badge.svg)][Thinkful]
-[Thinkful]: http://start.thinkful.com/node/?utm_source=github&utm_medium=badge&utm_campaign=node-oauth
+## License and Copyright
 
-Installation
-============== 
+This code is covered under the GNU GPL version 3 or later with parts of the code also covered by the MIT license.
+
+If you modify the code in this project, your changes will be under the GNU GPL version 3 or later.
+
+If you go to the original project and modify the code there, your changes will be under the MIT license.
+
+# Installation
 
     $ npm install oauth
 
 
-Examples
-==========
+# Examples
 
 To run examples/tests install Mocha `$ npm install -g mocha` and run `$ mocha you-file-name.js`:
 
@@ -76,8 +76,7 @@ describe('OAuth2',function(){
    });
 ```
 
-Change History
-============== 
+# Change History
 * 0.9.14
     - OAuth2:   Extend 'successful' token responses to include anything in the 2xx range.
 * 0.9.13
@@ -156,8 +155,7 @@ Change History
 * 0.7.0
     - OAuth1/2: Introduces support for HTTPS end points and callback URLS for OAuth 1.0A and Oauth 2 (Please be aware that this was a breaking change to the constructor arguments order)  
 
-Contributors (In no particular order)
-=====================================
+# Contributors (In no particular order)
 
 * Evan Prodromou
 * Jose Ignacio Andres

--- a/Readme.md
+++ b/Readme.md
@@ -22,6 +22,55 @@ If you go to the original project and modify the code there, your changes will b
 
 To run examples/tests install Mocha `$ npm install -g mocha` and run `$ mocha you-file-name.js`:
 
+## Using Promises
+
+Using promises is *optional*.
+
+Install the bluebird promises library:
+
+    npm install bluebird
+
+An example of using oauth-libre with Promises:
+
+```
+var OAuth2 = require('oauth-libre').PromiseOAuth2;
+
+var clientId = '';
+var clientSecret = '';
+
+// Fill these in:
+var user = 'USER';
+var personalAccessToken = 'PERSONAL_ACCESS_TOKEN';
+
+var baseSiteUrl = 'https://' + user + ':' + personalAccessToken + '@api.github.com/';
+var authorizePath = 'oauth2/authorize';
+var accessTokenPath = 'oauth2/access_token';
+var customHeaders = null;
+
+var oauth2 = new OAuth2(
+  clientId, clientSecret, baseSiteUrl, authorizePath, accessTokenPath, customHeaders
+);
+
+var url = 'https://api.github.com/users/' + user + '/received_events';
+oauth2
+  .get(url, personalAccessToken)
+  .then(jsonParse)
+  .then(function(json) {
+    for (var i = 0; i < json.length; i += 1) {
+      console.log(json[i]['id'] + ': ' + json[i].type);
+    }
+  })
+  .catch(function(err) {
+    console.log('Error: ' + err);
+  });
+
+function jsonParse(data) {
+  return JSON.parse(data);
+}
+```
+
+Note that in the first line you must explicitly import OAuth2 with promises.
+
 ## OAuth1.0
 
 ```javascript

--- a/examples/github-oauth2.js
+++ b/examples/github-oauth2.js
@@ -1,0 +1,34 @@
+var OAuth2 = require('../index').PromiseOAuth2;
+
+var clientId = '';
+var clientSecret = '';
+
+// Fill these in:
+var user = 'USER';
+var personalAccessToken = 'PERSONAL_ACCESS_TOKEN';
+
+var baseSiteUrl = 'https://' + user + ':' + personalAccessToken + '@api.github.com/';
+var authorizePath = 'oauth2/authorize';
+var accessTokenPath = 'oauth2/access_token';
+var customHeaders = null;
+
+var oauth2 = new OAuth2(
+  clientId, clientSecret, baseSiteUrl, authorizePath, accessTokenPath, customHeaders
+);
+
+var url = 'https://api.github.com/users/' + user + '/received_events';
+oauth2
+  .get(url, personalAccessToken)
+  .then(jsonParse)
+  .then(function(json) {
+    for (var i = 0; i < json.length; i += 1) {
+      console.log(json[i]['id'] + ': ' + json[i].type);
+    }
+  })
+  .catch(function(err) {
+    console.log('Error: ' + err);
+  });
+
+function jsonParse(data) {
+  return JSON.parse(data);
+}

--- a/examples/promise-twitter-example.js
+++ b/examples/promise-twitter-example.js
@@ -1,0 +1,106 @@
+/*
+*
+* This is an example of the original Twitter OAuth 1
+* example, ported over to use the promise library.
+*
+* NOTE: Express should be installed (included here for ease of use,
+*     if you're not using Express, this can be easily done
+*     through Node's http.createSever() call.
+*
+*/
+
+var http = require('http');
+var oauth = require('../lib/oauth-promise').OAuth;
+var express = require('express');
+
+const callbackURL = 'http://localhost:5000/oauth_callback';
+const yourConsumerKey = 'INSERT YOUR CONSUMER KEY HERE';
+const yourConsumerSecret = 'INSERT YOUR CONSUMER SECRET KEY HERE';
+
+var reqTokenSecrets = {}; // Hash that contains the req_token:req_token_secret key vals
+
+
+/*
+ STEP 1 - init the OAuth Client!
+ */
+var oa = new oauth(
+  'https://api.twitter.com/oauth/request_token',
+  'https://api.twitter.com/oauth/access_token',
+  yourConsumerKey,            // CONSUMER KEY
+  yourConsumerSecret,         // CONSUMER SECRET
+  '1.0',
+  callbackURL,
+  'HMAC-SHA1'
+);
+
+var app = express();
+app.get('/', function(req, res){
+
+
+  // STEP 2: Ask twitter for a signed request token
+
+  // oAuthToken/Secret used for this this handshake process
+  var requestTokenPromise = oa.getOAuthRequestToken();
+
+
+  /*
+    Promise returns data array in the format:
+
+    data[0]: oauth_token
+    data[1]: oauth_token_secret
+    data[2]: results
+
+   */
+  requestTokenPromise.then(function(data){
+
+    // Extract data
+    var oauthToken = data[0];
+    var oauthTokenSecret = data[1];
+
+    // Get the secret oauth request token
+    reqTokenSecrets[oauthToken] = oauthTokenSecret;
+
+    // Redirect user to Twitter Auth
+    var redirectURL = 'https://api.twitter.com/oauth/authorize'+'?oauth_token='+oauthToken;
+    res.redirect(redirectURL);
+
+  });
+
+});
+
+
+app.get('/oauth_callback', function(req, res){
+
+  // This is where we get the oauth  token, oauth verifier, and give the oauth token secret as well
+
+  /**
+   * STEP 4: Get the access token and access token secret - finally what we need! :)
+   */
+  var accessTokenPromise = oa.getOAuthAccessToken(req.query.oauth_token,
+                                                  reqTokenSecrets[req.query.oauth_token],
+                                                  req.query.oauth_verifier);
+
+  /*
+    Similar to access token:
+    data[0]: access token
+    data[1]: access token secret
+    data[2]: results
+   */
+  accessTokenPromise.then(function(data){
+
+    var accessToken = data[0];
+    var accessTokenSecret = data[1];
+    var results = data[2];
+
+
+      // here we get access token, access token secret - this is what we use to access the
+      // user's Twitter resources, you want to store this!
+      res.send('Acc token: ' + accessToken  + ' \nAcc token secret: ' + accessTokenSecret);
+    });
+
+  });
+
+app.listen(5000, function(){
+  console.log('Listening on port 5000');
+});
+

--- a/examples/twitter-oauth-promises.js
+++ b/examples/twitter-oauth-promises.js
@@ -1,0 +1,40 @@
+var OAuth = require('../index').PromiseOAuth;
+
+// Setting up the OAuth client
+var requestUrl = 'https://api.twitter.com/oauth/request_token';
+var accessUrl = 'https://api.twitter.com/oauth/access_token';
+var version = '1.0';
+var authorizeCallback = 'oob';
+var signatureMethod = 'HMAC-SHA1';
+var nonceSize = null;
+var customHeaders = null;
+
+// Go to https://dev.twitter.com/oauth/overview/application-owner-access-tokens
+// to fill these in:
+var consumerKey = 'your consumer key';
+var consumerSecret = 'your consumer secret';
+
+var client = new OAuth(
+  requestUrl, accessUrl,
+  consumerKey, consumerSecret,
+  version,
+  authorizeCallback,
+  signatureMethod,
+  nonceSize,
+  customHeaders
+);
+
+// Making a request to the API
+var url = 'https://api.twitter.com/1.1/statuses/home_timeline.json';
+
+// Go to https://dev.twitter.com/oauth/overview/application-owner-access-tokens
+// to fill these in:
+var accessToken = 'your access token';
+var accessTokenSecret = 'your access token secret';
+
+client.get(url, accessToken, accessTokenSecret).then(function(data, response) {
+  console.log('Data: ' + data);
+  console.log('Response: ' + response);
+}).catch(function(err) {
+  console.log('Error: ' + error);
+});

--- a/index.js
+++ b/index.js
@@ -1,3 +1,4 @@
 exports.OAuth = require("./lib/oauth").OAuth;
 exports.OAuthEcho = require("./lib/oauth").OAuthEcho;
 exports.OAuth2 = require("./lib/oauth2").OAuth2;
+exports.PromiseOAuth2 = require("./lib/oauth2-promise").OAuth2;

--- a/index.js
+++ b/index.js
@@ -1,4 +1,5 @@
 exports.OAuth = require("./lib/oauth").OAuth;
 exports.OAuthEcho = require("./lib/oauth").OAuthEcho;
 exports.OAuth2 = require("./lib/oauth2").OAuth2;
+exports.PromiseOAuth = require("./lib/oauth-promise").OAuth;
 exports.PromiseOAuth2 = require("./lib/oauth2-promise").OAuth2;

--- a/lib/oauth-promise.js
+++ b/lib/oauth-promise.js
@@ -3,7 +3,7 @@ var _OAuth = require('./oauth').OAuth;
 
 var OAuth = function(requestUrl, accessUrl, consumerKey, consumerSecret, version, authorize_callback, signatureMethod, nonceSize, customHeaders) {
   this._oa = new _OAuth(requestUrl, accessUrl, consumerKey, consumerSecret, version, authorize_callback, signatureMethod, nonceSize, customHeaders);
-  this._oa.prototype = Promise.promisifyAll(_OAuth.prototype);
+  this._oa.prototype = Promise.promisifyAll(_OAuth.prototype, { multiArgs: true });
 };
 
 // Promisifed public API for OAuth

--- a/lib/oauth-promise.js
+++ b/lib/oauth-promise.js
@@ -13,8 +13,7 @@ var delegatedPromiseMethods = [
   'getOAuthAccessToken',
   'getOAuthRequestToken',
   'post',
-  'put',
-  'signUrl'
+  'put'
 ];
 
 delegatedPromiseMethods.forEach(asyncDelegate);
@@ -24,6 +23,7 @@ var delegatedMethods = [
   'authHeader',
   'getProtectedResource',
   'setClientOptions',
+  'signUrl',
 
   // Required for testing
   '_buildAuthorizationHeaders',

--- a/lib/oauth-promise.js
+++ b/lib/oauth-promise.js
@@ -1,0 +1,58 @@
+var Promise = require('bluebird');
+var _OAuth = require('./oauth').OAuth;
+
+var OAuth = function(requestUrl, accessUrl, consumerKey, consumerSecret, version, authorize_callback, signatureMethod, nonceSize, customHeaders) {
+  this._oa = new _OAuth(requestUrl, accessUrl, consumerKey, consumerSecret, version, authorize_callback, signatureMethod, nonceSize, customHeaders);
+  this._oa.prototype = Promise.promisifyAll(_OAuth.prototype);
+};
+
+// Promisifed public API for OAuth
+var delegatedPromiseMethods = [
+  'delete',
+  'get',
+  'getOAuthAccessToken',
+  'getOAuthRequestToken',
+  'post',
+  'put',
+  'signUrl'
+];
+
+delegatedPromiseMethods.forEach(asyncDelegate);
+
+// delegates PromiseOAuth.methodName to OAuth.methodName
+var delegatedMethods = [
+  'authHeader',
+  'getProtectedResource',
+  'setClientOptions',
+
+  // Required for testing
+  '_buildAuthorizationHeaders',
+  '_createSignature',
+  '_createSignatureBase',
+  '_encodeData',
+  '_getNonce',
+  '_getSignature',
+  '_getTimestamp',
+  '_makeArrayOfArgumentsHash',
+  '_normaliseRequestParams',
+  '_normalizeUrl',
+  '_performSecureRequest',
+  '_prepareParameters',
+  '_sortRequestParams'
+];
+
+delegatedMethods.forEach(delegate);
+
+function delegate(methodName) {
+  OAuth.prototype[methodName] = function() {
+    return this._oa[methodName].apply(this._oa, arguments);
+  };
+}
+
+function asyncDelegate(methodName) {
+  OAuth.prototype[methodName] = function() {
+    return this._oa[methodName + 'Async'].apply(this._oa, arguments);
+  };
+}
+
+exports.OAuth = OAuth;

--- a/lib/oauth-promise.js
+++ b/lib/oauth-promise.js
@@ -33,6 +33,7 @@ var delegatedMethods = [
   '_getNonce',
   '_getSignature',
   '_getTimestamp',
+  '_isParameterNameAnOAuthParameter',
   '_makeArrayOfArgumentsHash',
   '_normaliseRequestParams',
   '_normalizeUrl',

--- a/lib/oauth2-promise.js
+++ b/lib/oauth2-promise.js
@@ -1,0 +1,38 @@
+var Promise = require('bluebird');
+var _OAuth2 = require('./oauth2').OAuth2;
+
+var OAuth2 = function(clientId, clientSecret, baseSite, authorizePath, accessTokenPath, customHeaders) {
+  this._oa = new _OAuth2(clientId, clientSecret, baseSite, authorizePath, accessTokenPath, customHeaders);
+  this._oa.prototype = Promise.promisifyAll(_OAuth2.prototype);
+};
+
+// Promisfied public API for OAuth2
+OAuth2.prototype.getOAuthAccessToken = function() {
+  return this._oa.getOAuthAccessTokenAsync.apply(this._oa, arguments);
+};
+
+OAuth2.prototype.get = function() {
+  return this._oa.getAsync.apply(this._oa, arguments);
+};
+
+// delegates PromiseOAuth2.methodName to OAuth2.methodName
+var delegatedMethods = [
+  'buildAuthHeader',
+  'getAuthorizeUrl',
+  'setAuthMethod',
+  'useAuthorizationHeaderforGET',
+
+  // Required for testing
+  '_executeRequest',
+  '_request'
+];
+
+delegatedMethods.forEach(delegate);
+
+function delegate(methodName) {
+  OAuth2.prototype[methodName] = function() {
+    return this._oa[methodName].apply(this._oa, arguments);
+  };
+}
+
+exports.OAuth2 = OAuth2;

--- a/lib/oauth2-promise.js
+++ b/lib/oauth2-promise.js
@@ -12,7 +12,9 @@ OAuth2.prototype.getOAuthAccessToken = function() {
 };
 
 OAuth2.prototype.get = function() {
-  return this._oa.getAsync.apply(this._oa, arguments);
+  return this._oa.getAsync.apply(this._oa, arguments).then(function(res) {
+    return res[0];
+  });
 };
 
 // delegates PromiseOAuth2.methodName to OAuth2.methodName

--- a/lib/oauth2-promise.js
+++ b/lib/oauth2-promise.js
@@ -3,7 +3,7 @@ var _OAuth2 = require('./oauth2').OAuth2;
 
 var OAuth2 = function(clientId, clientSecret, baseSite, authorizePath, accessTokenPath, customHeaders) {
   this._oa = new _OAuth2(clientId, clientSecret, baseSite, authorizePath, accessTokenPath, customHeaders);
-  this._oa.prototype = Promise.promisifyAll(_OAuth2.prototype);
+  this._oa.prototype = Promise.promisifyAll(_OAuth2.prototype, { multiArgs: true });
 };
 
 // Promisfied public API for OAuth2

--- a/package.json
+++ b/package.json
@@ -1,19 +1,28 @@
-{ "name" : "oauth"
-, "description" : "Library for interacting with OAuth 1.0, 1.0A, 2 and Echo.  Provides simplified client access and allows for construction of more complex apis and OAuth providers."
-, "version" : "0.9.14"
-, "directories" : { "lib" : "./lib" }
-, "main" : "index.js"
-, "author" : "Ciaran Jessup <ciaranj@gmail.com>"
-, "repository" : { "type":"git", "url":"http://github.com/ciaranj/node-oauth.git" }
-, "devDependencies": {
+{
+    "name" : "oauth",
+    "description": "Library for interacting with OAuth 1.0, 1.0A, 2 and Echo.  Provides simplified client access and allows for construction of more complex apis and OAuth providers.",
+    "version": "0.9.14",
+    "directories": {
+        "lib" : "./lib"
+    },
+    "main": "index.js",
+    "author": "Ciaran Jessup <ciaranj@gmail.com>",
+    "contributors": [
+        {
+            "name": "Rudolf Olah",
+            "email": "omouse@gmail.com"
+        }
+    ]
+    "repository": { "type":"git", "url":"http://github.com/omouse/node-oauth.git" },
+    "devDependencies": {
     "vows": "0.5.x"
   }
 , "scripts": {
     "test": "make test"
   }
 , "licenses" :
-  [ { "type" : "MIT"
-    , "url" : "http://github.com/ciaranj/node-oauth/raw/master/LICENSE"
+  [ { "type" : "GPL"
+    , "url" : "http://github.com/omouse/node-oauth/raw/master/LICENSE"
     }
   ]
 }

--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
       "url": "https://github.com/omouse/node-oauth-libre/raw/master/LICENSE.mit"
     }
   ],
-  "dependencies": {
+  "optionalDependencies": {
     "bluebird": "^3.3.4"
   }
 }

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-    "name" : "oauth",
+    "name" : "oauth-libre",
     "description": "Library for interacting with OAuth 1.0, 1.0A, 2 and Echo.  Provides simplified client access and allows for construction of more complex apis and OAuth providers.",
     "version": "0.9.14",
     "directories": {

--- a/package.json
+++ b/package.json
@@ -14,7 +14,10 @@
         }
     ]
     "repository": { "type":"git", "url":"http://github.com/omouse/node-oauth.git" },
-    "devDependencies": {
+  "dependencies": {
+    "bluebird": "^3.3.4"
+  },
+  "devDependencies": {
     "vows": "0.5.x"
   }
 , "scripts": {

--- a/tests/oauth2promise-tests.js
+++ b/tests/oauth2promise-tests.js
@@ -1,0 +1,290 @@
+var vows = require('vows'),
+    assert = require('assert'),
+    DummyResponse= require('./shared').DummyResponse,
+    DummyRequest= require('./shared').DummyRequest,
+    https = require('https'),
+    OAuth2= require('../lib/oauth2-promise').OAuth2,
+    url = require('url');
+
+vows.describe('OAuth2-Promise').addBatch({
+    'Given an OAuth2 instance with clientId and clientSecret, ': {
+      topic: new OAuth2("clientId", "clientSecret"),
+      'When dealing with the response from the OP': {
+        'we should treat a 201 response as a success': function(oa) {
+          var callbackCalled= false;
+          var http_library= {
+            request: function() {
+              return new DummyRequest(new DummyResponse(201));
+            }
+          };
+          oa._executeRequest( http_library, {}, null, function(err, result, response) {
+            callbackCalled= true;
+            assert.equal(err, null);
+          });
+          assert.ok(callbackCalled);
+        },
+        'we should treat a 200 response as a success': function(oa) {
+          var callbackCalled= false;
+          var http_library= {
+            request: function() {
+              return new DummyRequest(new DummyResponse(200));
+            }
+          };
+          oa._executeRequest( http_library, {}, null, function(err, result, response) {
+            callbackCalled= true;
+            assert.equal(err, null);
+          });
+          assert.ok(callbackCalled);
+        }
+      },
+      'When handling the access token response': {
+        'we should correctly extract the token if received as form-data': function (oa) {
+            oa._request= function( method, url, fo, bar, bleh, callback) {
+              callback(null, "access_token=access&refresh_token=refresh");
+            };
+            oa.getOAuthAccessToken("", {}, function(error, access_token, refresh_token) {
+              assert.equal( access_token, "access");
+              assert.equal( refresh_token, "refresh");
+            });
+        },
+        'we should not include access token in both querystring and headers (favours headers if specified)': function (oa) {
+            oa._request = new OAuth2("clientId", "clientSecret")._request.bind(oa);
+            oa._executeRequest= function( http_library, options, post_body, callback) {
+              callback(null, url.parse(options.path, true).query, options.headers);
+            };
+
+            oa._request("GET", "http://foo/", {"Authorization":"Bearer BadNews"}, null, "accessx",  function(error, query, headers) {
+              assert.ok( !('access_token' in query), "access_token also in query");
+              assert.ok( 'Authorization' in headers, "Authorization not in headers");
+            });
+        },
+        'we should include access token in the querystring if no Authorization header present to override it': function (oa) {
+           oa._request = new OAuth2("clientId", "clientSecret")._request.bind(oa);
+           oa._executeRequest= function( http_library, options, post_body, callback) {
+             callback(null, url.parse(options.path, true).query, options.headers);
+           };
+           oa._request("GET", "http://foo/", {}, null, "access",  function(error, query, headers) {
+             assert.ok( 'access_token' in query, "access_token not present in query");
+              assert.ok( !('Authorization' in headers), "Authorization in headers");
+            });
+        },
+        'we should correctly extract the token if received as a JSON literal': function (oa) {
+          oa._request= function(method, url, headers, post_body, access_token, callback) {
+            callback(null, '{"access_token":"access","refresh_token":"refresh"}');
+          };
+          oa.getOAuthAccessToken("", {}, function(error, access_token, refresh_token) {
+            assert.equal( access_token, "access");
+            assert.equal( refresh_token, "refresh");
+          });
+        },
+        'we should return the received data to the calling method': function (oa) {
+          oa._request= function(method, url, headers, post_body, access_token, callback) {
+            callback(null, '{"access_token":"access","refresh_token":"refresh","extra_1":1, "extra_2":"foo"}');
+          };
+          oa.getOAuthAccessToken("", {}, function(error, access_token, refresh_token, results) {
+            assert.equal( access_token, "access");
+            assert.equal( refresh_token, "refresh");
+            assert.isNotNull( results );
+            assert.equal( results.extra_1, 1);
+            assert.equal( results.extra_2, "foo");
+          });
+        }
+      },
+      'When no grant_type parameter is specified': {
+        'we should pass the value of the code argument as the code parameter': function(oa) {
+          oa._request= function(method, url, headers, post_body, access_token, callback) {
+            assert.isTrue( post_body.indexOf("code=xsds23") != -1 );
+          };
+          oa.getOAuthAccessToken("xsds23", {} );
+        }
+      },
+      'When an invalid grant_type parameter is specified': {
+        'we should pass the value of the code argument as the code parameter': function(oa) {
+          oa._request= function(method, url, headers, post_body, access_token, callback) {
+            assert.isTrue( post_body.indexOf("code=xsds23") != -1 );
+          };
+          oa.getOAuthAccessToken("xsds23", {grant_type:"refresh_toucan"} );
+        }
+      },
+      'When a grant_type parameter of value "refresh_token" is specified': {
+        'we should pass the value of the code argument as the refresh_token parameter, should pass a grant_type parameter, but shouldn\'t pass a code parameter' : function(oa) {
+          oa._request= function(method, url, headers, post_body, access_token, callback) {
+            assert.isTrue( post_body.indexOf("refresh_token=sdsds2") != -1 );
+            assert.isTrue( post_body.indexOf("grant_type=refresh_token") != -1 );
+            assert.isTrue( post_body.indexOf("code=") == -1 );
+          };
+          oa.getOAuthAccessToken("sdsds2", {grant_type:"refresh_token"} );
+        }
+      },
+      'When we use the authorization header': {
+        'and call get with the default authorization method': {
+          'we should pass the authorization header with Bearer method and value of the access_token, _request should be passed a null access_token' : function(oa) {
+            oa._request= function(method, url, headers, post_body, access_token, callback) {
+              assert.equal(headers["Authorization"], "Bearer abcd5");
+              assert.isNull( access_token );
+            };
+            oa.useAuthorizationHeaderforGET(true);
+            oa.get("", "abcd5");
+          }
+        },
+        'and call get with the authorization method set to Basic': {
+          'we should pass the authorization header with Basic method and value of the access_token, _request should be passed a null access_token' : function(oa) {
+            oa._request= function(method, url, headers, post_body, access_token, callback) {
+              assert.equal(headers["Authorization"], "Basic cdg2");
+              assert.isNull( access_token );
+            };
+            oa.useAuthorizationHeaderforGET(true);
+            oa.setAuthMethod("Basic");
+            oa.get("", "cdg2");
+          }
+        }
+      },
+      'When we do not use the authorization header': {
+        'and call get': {
+          'we should pass NOT provide an authorization header and the access_token should be being passed to _request' : function(oa) {
+            oa._request= function(method, url, headers, post_body, access_token, callback) {
+              assert.isUndefined(headers["Authorization"]);
+              assert.equal( access_token, "abcd5" );
+            };
+            oa.useAuthorizationHeaderforGET(false);
+            oa.get("", "abcd5");
+          }
+        }
+      }
+    },
+    'Given an OAuth2 instance with clientId, clientSecret and customHeaders': {
+      topic: new OAuth2("clientId", "clientSecret", undefined, undefined, undefined,
+          { 'SomeHeader': '123' }),
+      'When GETing': {
+        'we should see the custom headers mixed into headers property in options passed to http-library' : function(oa) {
+          oa._executeRequest= function( http_library, options, callback ) {
+            assert.equal(options.headers["SomeHeader"], "123");
+          };
+          oa.get("", {});
+        },
+      }
+    },
+    'Given an OAuth2 instance with a clientId and clientSecret': {
+      topic: new OAuth2("clientId", "clientSecret"),
+        'When POSTing': {
+          'we should see a given string being sent to the request' : function(oa) {
+            var bodyWritten= false;
+            oa._oa._chooseHttpLibrary= function() {
+              return {
+                request: function(options) {
+                  assert.equal(options.headers["Content-Type"], "text/plain");
+                  assert.equal(options.headers["Content-Length"], 26);
+                  assert.equal(options.method, "POST");
+                  return  {
+                    end: function() {},
+                    on: function() {},
+                    write: function(body) {
+                      bodyWritten= true;
+                      assert.isNotNull(body);
+                      assert.equal(body, "THIS_IS_A_POST_BODY_STRING")
+                    }
+                  }
+                }
+              };
+            }
+            oa._request("POST", "", {"Content-Type":"text/plain"}, "THIS_IS_A_POST_BODY_STRING");
+            assert.ok( bodyWritten );
+          },
+          'we should see a given buffer being sent to the request' : function(oa) {
+            var bodyWritten= false;
+            oa._oa._chooseHttpLibrary= function() {
+              return {
+                request: function(options) {
+                  assert.equal(options.headers["Content-Type"], "application/octet-stream");
+                  assert.equal(options.headers["Content-Length"], 4);
+                  assert.equal(options.method, "POST");
+                  return  {
+                    end: function() {},
+                    on: function() {},
+                    write: function(body) {
+                      bodyWritten= true;
+                      assert.isNotNull(body);
+                      assert.equal(4, body.length)
+                    }
+                  }
+                }
+              };
+            }
+            oa._request("POST", "", {"Content-Type":"application/octet-stream"}, new Buffer([1,2,3,4]));
+            assert.ok( bodyWritten );
+          }
+        },
+        'When PUTing': {
+          'we should see a given string being sent to the request' : function(oa) {
+            var bodyWritten= false;
+            oa._oa._chooseHttpLibrary= function() {
+              return {
+                request: function(options) {
+                  assert.equal(options.headers["Content-Type"], "text/plain");
+                  assert.equal(options.headers["Content-Length"], 25);
+                  assert.equal(options.method, "PUT");
+                  return  {
+                    end: function() {},
+                    on: function() {},
+                    write: function(body) {
+                      bodyWritten= true;
+                      assert.isNotNull(body);
+                      assert.equal(body, "THIS_IS_A_PUT_BODY_STRING")
+                    }
+                  }
+                }
+              };
+            }
+            oa._request("PUT", "", {"Content-Type":"text/plain"}, "THIS_IS_A_PUT_BODY_STRING");
+            assert.ok( bodyWritten );
+          },
+          'we should see a given buffer being sent to the request' : function(oa) {
+            var bodyWritten= false;
+            oa._oa._chooseHttpLibrary= function() {
+              return {
+                request: function(options) {
+                  assert.equal(options.headers["Content-Type"], "application/octet-stream");
+                  assert.equal(options.headers["Content-Length"], 4);
+                  assert.equal(options.method, "PUT");
+                  return  {
+                    end: function() {},
+                    on: function() {},
+                    write: function(body) {
+                      bodyWritten= true;
+                      assert.isNotNull(body);
+                      assert.equal(4, body.length)
+                    }
+                  }
+                }
+              };
+            }
+            oa._request("PUT", "", {"Content-Type":"application/octet-stream"}, new Buffer([1,2,3,4]));
+            assert.ok( bodyWritten );
+          }
+        }
+    },
+    'When the user passes in the User-Agent in customHeaders': {
+      topic: new OAuth2("clientId", "clientSecret", undefined, undefined, undefined,
+          { 'User-Agent': '123Agent' }),
+      'When calling get': {
+        'we should see the User-Agent mixed into headers property in options passed to http-library' : function(oa) {
+          oa._executeRequest= function( http_library, options, callback ) {
+            assert.equal(options.headers["User-Agent"], "123Agent");
+          };
+          oa.get("", {});
+        }
+      }
+    },
+    'When the user does not pass in a User-Agent in customHeaders': {
+      topic: new OAuth2("clientId", "clientSecret", undefined, undefined, undefined,
+        undefined),
+      'When calling get': {
+        'we should see the default User-Agent mixed into headers property in options passed to http-library' : function(oa) {
+          oa._executeRequest= function( http_library, options, callback ) {
+            assert.equal(options.headers["User-Agent"], "Node-oauth");
+            };
+          oa.get("", {});
+        }
+      }
+    }
+}).export(module);

--- a/tests/oauthpromise-tests.js
+++ b/tests/oauthpromise-tests.js
@@ -158,8 +158,8 @@ vows.describe('OAuth').addBatch({
   'When signing a url': {
     topic: function() {
       var oa= new OAuth(null, null, "consumerkey", "consumersecret", "1.0", null, "HMAC-SHA1");
-      oa._getTimestamp= function(){ return "1272399856"; };
-      oa._getNonce= function(){ return "ybHPeOEkAUJ3k2wJT9Xb43MjtSgTvKqp"; };
+      oa._oa._getTimestamp= function(){ return "1272399856"; };
+      oa._oa._getNonce= function(){ return "ybHPeOEkAUJ3k2wJT9Xb43MjtSgTvKqp"; };
       return oa;
     },
     'Provide a valid signature when no token present': function(oa) {

--- a/tests/oauthpromise-tests.js
+++ b/tests/oauthpromise-tests.js
@@ -53,9 +53,9 @@ vows.describe('OAuth').addBatch({
     'we get a valid oauth signature': function (oa) {
       var signatureBase = "GET&http%3A%2F%2Fphotos.example.net%2Fphotos&file%3Dvacation.jpg%26oauth_consumer_key%3Ddpf43f3p2l4k3l03%26oauth_nonce%3Dkllo9940pd9333jh%26oauth_signature_method%3DRSA-SHA1%26oauth_timestamp%3D1191242096%26oauth_token%3Dnnch734d00sl2jdk%26oauth_version%3D1.0%26size%3Doriginal";
       var oauthSignature = oa._createSignature(signatureBase, "xyz4992k83j47x0b");
-      
+
       assert.equal( oauthSignature, "qS4rhWog7GPgo4ZCJvUdC/1ZAax/Q4Ab9yOBvgxSopvmKUKp5rso+Zda46GbyN2hnYDTiA/g3P/d/YiPWa454BEBb/KWFV83HpLDIoqUUhJnlXX9MqRQQac0oeope4fWbGlfTdL2PXjSFJmvfrzybERD/ZufsFtVrQKS3QBpYiw=");
-      
+
       //now check that given the public key we can verify this signature
       var verifier = crypto.createVerify("RSA-SHA1").update(signatureBase);
       var valid = verifier.verify(RsaPublicKey, oauthSignature, 'base64');
@@ -81,7 +81,7 @@ vows.describe('OAuth').addBatch({
       assert.equal( oa._normalizeUrl("http://somehost.com:81/foo/bar"), "http://somehost.com:81/foo/bar" );
     },
     'should add a trailing slash when no path at all is present': function(oa) {
-      assert.equal( oa._normalizeUrl("http://somehost.com"),  "http://somehost.com/")
+      assert.equal(oa._normalizeUrl("http://somehost.com"), "http://somehost.com/");
     }
   },
   'When making an array out of the arguments hash' : {
@@ -104,7 +104,7 @@ vows.describe('OAuth').addBatch({
       var parameters= {"z": "a",
                        "a": "b",
                        "1": "c" };
-      var parameterResults= oa._sortRequestParams(oa._makeArrayOfArgumentsHash(parameters))
+      var parameterResults= oa._sortRequestParams(oa._makeArrayOfArgumentsHash(parameters));
       assert.equal(parameterResults[0][0], "1");
       assert.equal(parameterResults[1][0], "a");
       assert.equal(parameterResults[2][0], "z");
@@ -113,7 +113,7 @@ vows.describe('OAuth').addBatch({
       var parameters= {"z": "a",
                        "a": ["z", "b", "b", "a", "y"],
                        "1": "c" };
-      var parameterResults= oa._sortRequestParams(oa._makeArrayOfArgumentsHash(parameters))
+      var parameterResults= oa._sortRequestParams(oa._makeArrayOfArgumentsHash(parameters));
       assert.equal(parameterResults[0][0], "1");
       assert.equal(parameterResults[1][0], "a");
       assert.equal(parameterResults[1][1], "a");
@@ -149,17 +149,17 @@ vows.describe('OAuth').addBatch({
     topic: new OAuth(null, null, null, null, null, null, "HMAC-SHA1"),
     'We need to be wary of node\'s auto object creation from foo[bar] style url parameters' : function(oa) {
       var result= oa._prepareParameters( "", "", "", "http://foo.com?foo[bar]=xxx&bar[foo]=yyy", {} );
-      assert.equal( result[0][0], "bar[foo]")
-      assert.equal( result[0][1], "yyy")
-      assert.equal( result[1][0], "foo[bar]")
-      assert.equal( result[1][1], "xxx")
+      assert.equal( result[0][0], "bar[foo]");
+      assert.equal( result[0][1], "yyy");
+      assert.equal( result[1][0], "foo[bar]");
+      assert.equal( result[1][1], "xxx");
     }
   },
   'When signing a url': {
     topic: function() {
       var oa= new OAuth(null, null, "consumerkey", "consumersecret", "1.0", null, "HMAC-SHA1");
-      oa._getTimestamp= function(){ return "1272399856"; }
-      oa._getNonce= function(){ return "ybHPeOEkAUJ3k2wJT9Xb43MjtSgTvKqp"; }
+      oa._getTimestamp= function(){ return "1272399856"; };
+      oa._getNonce= function(){ return "ybHPeOEkAUJ3k2wJT9Xb43MjtSgTvKqp"; };
       return oa;
     },
     'Provide a valid signature when no token present': function(oa) {
@@ -175,9 +175,9 @@ vows.describe('OAuth').addBatch({
   'When getting a request token': {
     topic: function() {
       var oa= new OAuth(null, null, "consumerkey", "consumersecret", "1.0", null, "HMAC-SHA1");
-      oa._getTimestamp= function(){ return "1272399856"; }
-      oa._getNonce= function(){ return "ybHPeOEkAUJ3k2wJT9Xb43MjtSgTvKqp"; }
-      oa._performSecureRequest= function(){ return this.requestArguments = arguments; }
+      oa._getTimestamp= function(){ return "1272399856"; };
+      oa._getNonce= function(){ return "ybHPeOEkAUJ3k2wJT9Xb43MjtSgTvKqp"; };
+      oa._performSecureRequest= function(){ return this.requestArguments = arguments; };
       return oa;
     },
     'Use the HTTP method in the client options': function(oa) {
@@ -236,8 +236,8 @@ vows.describe('OAuth').addBatch({
       var realm = "http://foobar.com/";
       var verifyCredentials = "http://api.foobar.com/verify.json";
       var oa = new OAuthEcho(realm, verifyCredentials, "consumerkey", "consumersecret", "1.0A", "HMAC-SHA1");
-      oa._getTimestamp= function(){ return "1272399856"; }
-      oa._getNonce= function(){ return "ybHPeOEkAUJ3k2wJT9Xb43MjtSgTvKqp"; }
+      oa._getTimestamp= function(){ return "1272399856"; };
+      oa._getNonce= function(){ return "ybHPeOEkAUJ3k2wJT9Xb43MjtSgTvKqp"; };
       return oa;
     },
     'Provide a valid signature when a token and token secret is present': function (oa) {
@@ -257,11 +257,11 @@ vows.describe('OAuth').addBatch({
           on: function() {},
           end: function() {}
         };
-      }
+      };
       return oa;
     },
     'getProtectedResource should correctly define the host headers': function(oa) {
-      oa.getProtectedResource("http://somehost.com:8080", "GET", "oauth_token", null, function(){})
+      oa.getProtectedResource("http://somehost.com:8080", "GET", "oauth_token", null, function(){});
     }
   },
   'When building the OAuth Authorization header': {
@@ -320,7 +320,7 @@ vows.describe('OAuth').addBatch({
                 assert.equal(post_body,"scope=foobar%2C1%2C2");
               }
             };
-          }
+          };
           oa._performSecureRequest("token", "token_secret", 'POST', 'http://foo.com/protected_resource', {"scope": "foobar,1,2"});
           assert.equal(post_body_written, true);
         }
@@ -338,7 +338,7 @@ vows.describe('OAuth').addBatch({
     'POST' : {
       'if no callback is passed' : {
         'it should return a request object': function(oa) {
-          var request= oa.post("http://foo.com/blah", "token", "token_secret", "BLAH", "text/plain")
+          var request= oa.post("http://foo.com/blah", "token", "token_secret", "BLAH", "text/plain");
           assert.isObject(request);
           assert.equal(request.method, "POST");
           request.end();
@@ -357,8 +357,8 @@ vows.describe('OAuth').addBatch({
                   callbackCalled= true;
                 }
               };
-            }
-            var request= oa.post("http://foo.com/blah", "token", "token_secret", "BLAH", "text/plain", function(e,d){})
+            };
+            var request= oa.post("http://foo.com/blah", "token", "token_secret", "BLAH", "text/plain", function(e,d){});
             assert.equal(callbackCalled, true);
             assert.isUndefined(request);
           }
@@ -373,7 +373,7 @@ vows.describe('OAuth').addBatch({
           try {
             var callbackCalled= false;
             oa._createClient= function( port, hostname, method, path, headers, sshEnabled ) {
-              assert.equal(headers["Content-Type"], "image/jpeg")
+              assert.equal(headers["Content-Type"], "image/jpeg");
               return {
                 write: function(data){
                   callbackCalled= true;
@@ -418,15 +418,15 @@ vows.describe('OAuth').addBatch({
         }
       },
       'if the post_body is not a string or a buffer' : {
-        "It should be url encoded and the content type set to be x-www-form-urlencoded" : function(oa) {
-          var op= oa._createClient;
+        "It should be url encoded and the content type set to be x-www-form-urlencoded": function(oa) {
+          var op = oa._createClient;
           try {
             var callbackCalled= false;
-            oa._createClient= function( port, hostname, method, path, headers, sshEnabled ) {
+            oa._createClient= function(port, hostname, method, path, headers, sshEnabled) {
               assert.equal(headers["Content-Type"], "application/x-www-form-urlencoded");
               return {
-                write: function(data){
-                  callbackCalled= true;
+                write: function(data) {
+                  callbackCalled = true;
                   assert.equal(data, "foo=1%2C2%2C3&bar=1%2B2");
                 },
                 on: function() {},
@@ -434,10 +434,9 @@ vows.describe('OAuth').addBatch({
                 }
               };
             };
-            var request= oa.post("http://foo.com/blah", "token", "token_secret", {"foo":"1,2,3", "bar":"1+2"});
+            var request = oa.post("http://foo.com/blah", "token", "token_secret", { "foo": "1,2,3", "bar": "1+2" });
             assert.equal(callbackCalled, true);
-          }
-          finally {
+          } finally {
             oa._createClient= op;
           }
         }
@@ -839,64 +838,58 @@ vows.describe('OAuth').addBatch({
             var op= oa._createClient;
             var callbackCalled = false;
             try {
-              oa._createClient= function( port, hostname, method, path, headers, sshEnabled ) {
-                return new DummyRequest( new DummyResponse(301) );
+              oa._oa._createClient = function (port, hostname, method, path, headers, sshEnabled) {
+                return new DummyRequest(new DummyResponse(301));
               };
-              oa._performSecureRequest("token", "token_secret", 'POST', 'http://originalurl.com', {"scope": "foobar,1,2"}, null, null, function(error) {
-                // callback
+              oa._oa._performSecureRequest("token", "token_secret", 'POST', 'http://originalurl.com', { "scope": "foobar,1,2" }, null, null, function(error) {
                 assert.equal(error.statusCode, 301);
-                callbackCalled= true;
+                callbackCalled = true;
               });
               assert.equal(callbackCalled, true);
-            }
-            finally {
-              oa._createClient= op;
+            } finally {
+              oa._oa._createClient = op;
             }
           }
         },
         'and followRedirect is true' : {
           'it should (re)perform the secure request but with the new location' : function(oa) {
-            var op= oa._createClient;
-            var psr= oa._performSecureRequest;
+            var op = oa._oa._createClient;
+            var psr = oa._oa._performSecureRequest;
             var responseCounter = 1;
             var callbackCalled = false;
-            var DummyResponse =function() {
-              if( responseCounter == 1 ){
-                this.statusCode= 301;
-                this.headers= {location:"http://redirectto.com"};
+            var DummyResponse = function() {
+              if (responseCounter === 1) {
+                this.statusCode = 301;
+                this.headers = { location: "http://redirectto.com" };
                 responseCounter++;
-              }
-              else {
-                this.statusCode= 200;
+              } else {
+                this.statusCode = 200;
               }
             };
-            DummyResponse.prototype= events.EventEmitter.prototype;
+            DummyResponse.prototype = events.EventEmitter.prototype;
             DummyResponse.prototype.setEncoding = function() {};
 
             try {
-              oa._createClient= function( port, hostname, method, path, headers, sshEnabled ) {
-                return new DummyRequest( new DummyResponse() );
+              oa._oa._createClient = function(port, hostname, method, path, headers, sshEnabled) {
+                return new DummyRequest(new DummyResponse());
               };
-              oa._performSecureRequest= function( oauth_token, oauth_token_secret, method, url, extra_params, post_body, post_content_type,  callback ) {
-                if( responseCounter == 1 ) {
+              oa._oa._performSecureRequest = function(oauth_token, oauth_token_secret, method, url, extra_params, post_body, post_content_type,  callback) {
+                if (responseCounter === 1) {
                   assert.equal(url, "http://originalurl.com");
-                }
-                else {
+                } else {
                   assert.equal(url, "http://redirectto.com");
                 }
-                return psr.call(oa, oauth_token, oauth_token_secret, method, url, extra_params, post_body, post_content_type,  callback );
+                return psr.call(oa._oa, oauth_token, oauth_token_secret, method, url, extra_params, post_body, post_content_type, callback);
               };
 
-              oa._performSecureRequest("token", "token_secret", 'POST', 'http://originalurl.com', {"scope": "foobar,1,2"}, null, null, function() {
-                // callback
+              oa._oa._performSecureRequest("token", "token_secret", 'POST', 'http://originalurl.com', { "scope": "foobar,1,2" }, null, null, function() {
                 assert.equal(responseCounter, 2);
-                callbackCalled= true;
+                callbackCalled = true;
               });
-              assert.equal(callbackCalled, true)
-            }
-            finally {
-              oa._createClient= op;
-              oa._performSecureRequest= psr;
+              assert.equal(callbackCalled, true);
+            } finally {
+              oa._oa._createClient = op;
+              oa._oa._performSecureRequest = psr;
             }
           }
         },
@@ -907,142 +900,6 @@ vows.describe('OAuth').addBatch({
             var DummyResponse =function() {
               this.statusCode= 301;
               this.headers= {location:"http://redirectto.com"};
-            }
-            DummyResponse.prototype= events.EventEmitter.prototype;
-            DummyResponse.prototype.setEncoding= function() {}
-
-            try {
-              oa._createClient= function( port, hostname, method, path, headers, sshEnabled ) {
-                return new DummyRequest( new DummyResponse() );
-              }
-              oa._performSecureRequest("token", "token_secret", 'POST', 'http://originalurl.com', {"scope": "foobar,1,2"}, null, null, function(res, data, response) {
-                // callback
-                assert.equal(res.statusCode, 301);
-              });
-            }
-            finally {
-              oa._createClient= op;
-              oa.setClientOptions({followRedirects:true});
-            }
-          }
-        }
-      },
-      'And A 302 redirect is received' : {
-        'and there is a location header' : {
-          'it should (re)perform the secure request but with the new location' : function(oa) {
-            var op= oa._createClient;
-            var psr= oa._performSecureRequest;
-            var responseCounter = 1;
-            var callbackCalled = false;
-            var DummyResponse =function() {
-              if( responseCounter == 1 ){
-                this.statusCode= 302;
-                this.headers= {location:"http://redirectto.com"};
-                responseCounter++;
-              } else {
-                this.statusCode= 200;
-              }
-            };
-            DummyResponse.prototype= events.EventEmitter.prototype;
-            DummyResponse.prototype.setEncoding = function() {};
-
-            try {
-              oa._createClient= function( port, hostname, method, path, headers, sshEnabled ) {
-                return new DummyRequest( new DummyResponse() );
-              }
-              oa._performSecureRequest= function( oauth_token, oauth_token_secret, method, url, extra_params, post_body, post_content_type,  callback ) {
-                if( responseCounter == 1 ) {
-                  assert.equal(url, "http://originalurl.com");
-                } else {
-                  assert.equal(url, "http://redirectto.com");
-                }
-                return psr.call(oa, oauth_token, oauth_token_secret, method, url, extra_params, post_body, post_content_type,  callback )
-              }
-
-              oa._performSecureRequest("token", "token_secret", 'POST', 'http://originalurl.com', {"scope": "foobar,1,2"}, null, null, function() {
-                // callback
-                assert.equal(responseCounter, 2);
-                callbackCalled = true;
-              });
-              assert.equal(callbackCalled, true);
-            }
-            finally {
-              oa._createClient= op;
-              oa._performSecureRequest= psr;
-            }
-          }
-        },
-        'but there is no location header' : {
-          'it should execute the callback, passing the HTTP Response code' : function(oa) {
-            var op= oa._createClient;
-            var callbackCalled = false;
-            try {
-              oa._createClient = function(port, hostname, method, path, headers, sshEnabled ) {
-                return new DummyRequest(new DummyResponse(302));
-              };
-              oa._performSecureRequest("token", "token_secret", 'POST', 'http://originalurl.com', {"scope": "foobar,1,2"}, null, null, function(error) {
-                // callback
-                assert.equal(error.statusCode, 302);
-                callbackCalled = true;
-              });
-              assert.equal(callbackCalled, true);
-            }
-            finally {
-              oa._createClient= op;
-            }
-          }
-        },
-        'and followRedirect is true' : {
-          'it should (re)perform the secure request but with the new location' : function(oa) {
-            var op= oa._createClient;
-            var psr= oa._performSecureRequest;
-            var responseCounter = 1;
-            var callbackCalled = false;
-            var DummyResponse = function() {
-              if (responseCounter == 1) {
-                this.statusCode= 302;
-                this.headers= {location:"http://redirectto.com"};
-                responseCounter++;
-              } else {
-                this.statusCode= 200;
-              }
-            };
-            DummyResponse.prototype= events.EventEmitter.prototype;
-            DummyResponse.prototype.setEncoding = function() {};
-
-            try {
-              oa._createClient = function(port, hostname, method, path, headers, sshEnabled) {
-                return new DummyRequest(new DummyResponse());
-              };
-              oa._performSecureRequest = function(oauth_token, oauth_token_secret, method, url, extra_params, post_body, post_content_type,  callback) {
-                if (responseCounter == 1) {
-                  assert.equal(url, "http://originalurl.com");
-                } else {
-                  assert.equal(url, "http://redirectto.com");
-                }
-                return psr.call(oa, oauth_token, oauth_token_secret, method, url, extra_params, post_body, post_content_type, callback);
-              };
-
-              oa._performSecureRequest("token", "token_secret", 'POST', 'http://originalurl.com', {"scope": "foobar,1,2"}, null, null, function() {
-                // callback
-                assert.equal(responseCounter, 2);
-                callbackCalled = true;
-              });
-              assert.equal(callbackCalled, true);
-            }
-            finally {
-              oa._createClient= op;
-              oa._performSecureRequest= psr;
-            }
-          }
-        },
-        'and followRedirect is false' : {
-          'it should not perform the secure request with the new location' : function(oa) {
-            var op= oa._createClient;
-            oa.setClientOptions({ followRedirects: false });
-            var DummyResponse =function() {
-              this.statusCode= 302;
-              this.headers= {location:"http://redirectto.com"};
             };
             DummyResponse.prototype= events.EventEmitter.prototype;
             DummyResponse.prototype.setEncoding= function() {};
@@ -1051,14 +908,156 @@ vows.describe('OAuth').addBatch({
               oa._createClient= function( port, hostname, method, path, headers, sshEnabled ) {
                 return new DummyRequest( new DummyResponse() );
               };
-              oa._performSecureRequest("token", "token_secret", 'POST', 'http://originalurl.com', {"scope": "foobar,1,2"}, null, null, function(res, data, response) {
+              oa._performSecureRequest("token", "token_secret", 'POST', 'http://originalurl.com', { "scope": "foobar,1,2" }, null, null, function(res, data, response) {
+                assert.equal(res.statusCode, 301);
+              });
+            } finally {
+              oa._createClient = op;
+              oa.setClientOptions({ followRedirects: true });
+            }
+          }
+        }
+      },
+      'And A 302 redirect is received' : {
+        'and there is a location header' : {
+          'it should (re)perform the secure request but with the new location' : function(oa) {
+            var op = oa._oa._createClient;
+            var psr = oa._oa._performSecureRequest;
+            var responseCounter = 1;
+            var callbackCalled = false;
+            var DummyResponse = function() {
+              if( responseCounter === 1 ){
+                this.statusCode = 302;
+                this.headers = { location: "http://redirectto.com" };
+                responseCounter++;
+              } else {
+                this.statusCode = 200;
+              }
+            };
+            DummyResponse.prototype = events.EventEmitter.prototype;
+            DummyResponse.prototype.setEncoding = function() {};
+
+            try {
+              oa._oa._createClient= function(port, hostname, method, path, headers, sshEnabled) {
+                return new DummyRequest(new DummyResponse());
+              };
+              oa._oa._performSecureRequest = function(oauth_token, oauth_token_secret, method, url, extra_params, post_body, post_content_type,  callback) {
+                if (responseCounter === 1) {
+                  assert.equal(url, "http://originalurl.com");
+                } else {
+                  assert.equal(url, "http://redirectto.com");
+                }
+                return psr.call(oa._oa, oauth_token, oauth_token_secret, method, url, extra_params, post_body, post_content_type,  callback);
+              };
+
+              oa._oa._performSecureRequest("token", "token_secret", 'POST', 'http://originalurl.com', { "scope": "foobar,1,2" }, null, null, function() {
+                // callback
+                assert.equal(responseCounter, 2);
+                callbackCalled = true;
+              });
+              assert.equal(callbackCalled, true);
+            } finally {
+              oa._oa._createClient = op;
+              oa._oa._performSecureRequest = psr;
+            }
+          }
+        },
+        'but there is no location header': {
+          'it should execute the callback, passing the HTTP Response code': function(oa) {
+            var op = oa._oa._createClient;
+            var callbackCalled = false;
+            try {
+
+              oa._oa._createClient = function(port, hostname, method, path, headers, sshEnabled ) {
+                return new DummyRequest(new DummyResponse(302));
+              };
+              oa._oa._performSecureRequest("token", "token_secret", 'POST', 'http://originalurl.com', { "scope": "foobar,1,2" }, null, null, function(error) {
+                assert.equal(error.statusCode, 302);
+                callbackCalled = true;
+              });
+              assert.equal(callbackCalled, true);
+
+            } finally {
+              oa._oa._createClient = op;
+            }
+          }
+        },
+        'and followRedirect is true': {
+          'it should (re)perform the secure request but with the new location': function(oa) {
+            var op = oa._oa._createClient;
+            var psr = oa._oa._performSecureRequest;
+            var responseCounter = 1;
+            var callbackCalled = false;
+            var DummyResponse = function() {
+
+              if (responseCounter === 1) {
+                this.statusCode = 302;
+                this.headers = {
+                  location: 'http://redirectto.com'
+                };
+                responseCounter++;
+              } else {
+                this.statusCode = 200;
+              }
+
+            };
+            DummyResponse.prototype = events.EventEmitter.prototype;
+            DummyResponse.prototype.setEncoding = function() {};
+
+            try {
+
+              oa._oa._createClient = function(port, hostname, method, path, headers, sshEnabled) {
+                return new DummyRequest(new DummyResponse());
+              };
+              oa._oa._performSecureRequest = function(oauth_token, oauth_token_secret, method, url, extra_params, post_body, post_content_type,  callback) {
+
+                if (responseCounter === 1) {
+                  assert.equal(url, 'http://originalurl.com');
+                } else {
+                  assert.equal(url, 'http://redirectto.com');
+                }
+
+                return psr.call(oa._oa, oauth_token, oauth_token_secret, method, url, extra_params, post_body, post_content_type, callback);
+              };
+              oa._oa._performSecureRequest('token', 'token_secret', 'POST', 'http://originalurl.com', { 'scope': 'foobar,1,2' }, null, null, function() {
+                // callback
+                assert.equal(responseCounter, 2);
+                callbackCalled = true;
+              });
+              assert.equal(callbackCalled, true);
+
+            } finally {
+
+              oa._oa._createClient = op;
+              oa._oa._performSecureRequest = psr;
+
+            }
+          }
+        },
+        'and followRedirect is false': {
+          'it should not perform the secure request with the new location': function(oa) {
+            var op = oa._oa._createClient;
+            oa.setClientOptions({ followRedirects: false });
+            var DummyResponse = function() {
+              this.statusCode = 302;
+              this.headers = {
+                location: 'http://redirectto.com'
+              };
+            };
+            DummyResponse.prototype = events.EventEmitter.prototype;
+            DummyResponse.prototype.setEncoding = function() {};
+
+            try {
+              oa._oa._createClient= function(port, hostname, method, path, headers, sshEnabled) {
+                return new DummyRequest(new DummyResponse());
+              };
+              oa._oa._performSecureRequest('token', 'token_secret', 'POST', 'http://originalurl.com', { 'scope': 'foobar,1,2' }, null, null, function(res, data, response) {
                 // callback
                 assert.equal(res.statusCode, 302);
               });
-            }
-            finally {
-              oa._createClient= op;
-              oa.setClientOptions({followRedirects:true});
+            } finally {
+              oa._createClient = op;
+              oa.setClientOptions({ followRedirects: true });
             }
           }
         }

--- a/tests/oauthpromise-tests.js
+++ b/tests/oauthpromise-tests.js
@@ -1,0 +1,1068 @@
+var vows = require('vows'),
+    assert = require('assert'),
+    DummyResponse= require('./shared').DummyResponse,
+    DummyRequest= require('./shared').DummyRequest,
+    events = require('events'),
+    OAuth= require('../lib/oauth-promise').OAuth,
+    OAuthEcho= require('../lib/oauth').OAuthEcho,
+    crypto = require('crypto');
+
+//Valid RSA keypair used to test RSA-SHA1 signature method
+var RsaPrivateKey = "-----BEGIN RSA PRIVATE KEY-----\n" +
+      "MIICXQIBAAKBgQDizE4gQP5nPQhzof/Vp2U2DDY3UY/Gxha2CwKW0URe7McxtnmE\n" +
+      "CrZnT1n/YtfrrCNxY5KMP4o8hMrxsYEe05+1ZGFT68ztms3puUxilU5E3BQMhz1t\n" +
+      "JMJEGcTt8nZUlM4utli7fHgDtWbhvqvYjRMGn3AjyLOfY8XZvnFkGjipvQIDAQAB\n" +
+      "AoGAKgk6FcpWHOZ4EY6eL4iGPt1Gkzw/zNTcUsN5qGCDLqDuTq2Gmk2t/zn68VXt\n" +
+      "tVXDf/m3qN0CDzOBtghzaTZKLGhnSewQ98obMWgPcvAsb4adEEeW1/xigbMiaW2X\n" +
+      "cu6GhZxY16edbuQ40LRrPoVK94nXQpj8p7w4IQ301Sm8PSECQQD1ZlOj4ugvfhEt\n" +
+      "exi4WyAaM45fylmN290UXYqZ8SYPI/VliDytIlMfyq5Rv+l+dud1XDPrWOQ0ImgV\n" +
+      "HJn7uvoZAkEA7JhHNmHF9dbdF9Koj86K2Cl6c8KUu7U7d2BAuB6pPkt8+D8+y4St\n" +
+      "PaCmN4oP4X+sf5rqBYoXywHlqEei2BdpRQJBAMYgR4cZu7wcXGIL8HlnmROObHSK\n" +
+      "OqN9z5CRtUV0nPW8YnQG+nYOMG6KhRMbjri750OpnYF100kEPmRNI0VKQIECQE8R\n" +
+      "fQsRleTYz768ahTVQ9WF1ySErMwmfx8gDcD6jjkBZVxZVpURXAwyehopi7Eix/VF\n" +
+      "QlxjkBwKIEQi3Ks297kCQQCL9by1bueKDMJO2YX1Brm767pkDKkWtGfPS+d3xMtC\n" +
+      "KJHHCqrS1V+D5Q89x5wIRHKxE5UMTc0JNa554OxwFORX\n" +
+      "-----END RSA PRIVATE KEY-----";
+
+var RsaPublicKey = "-----BEGIN PUBLIC KEY-----\n" +
+      "MIGfMA0GCSqGSIb3DQEBAQUAA4GNADCBiQKBgQDizE4gQP5nPQhzof/Vp2U2DDY3\n" +
+      "UY/Gxha2CwKW0URe7McxtnmECrZnT1n/YtfrrCNxY5KMP4o8hMrxsYEe05+1ZGFT\n" +
+      "68ztms3puUxilU5E3BQMhz1tJMJEGcTt8nZUlM4utli7fHgDtWbhvqvYjRMGn3Aj\n" +
+      "yLOfY8XZvnFkGjipvQIDAQAB\n" +
+      "-----END PUBLIC KEY-----";
+
+vows.describe('OAuth').addBatch({
+  'When newing OAuth': {
+    topic: new OAuth(null, null, null, null, null, null, "PLAINTEXT"),
+    'followRedirects is enabled by default': function (oa) {
+      assert.equal(oa._oa._clientOptions.followRedirects, true);
+    }
+  },
+  'When generating the signature base string described in http://oauth.net/core/1.0/#sig_base_example': {
+    topic: new OAuth(null, null, null, null, null, null, "HMAC-SHA1"),
+    'we get the expected result string': function (oa) {
+      var result= oa._createSignatureBase(
+        "GET", "http://photos.example.net/photos",
+        "file=vacation.jpg&oauth_consumer_key=dpf43f3p2l4k3l03&oauth_nonce=kllo9940pd9333jh&oauth_signature_method=HMAC-SHA1&oauth_timestamp=1191242096&oauth_token=nnch734d00sl2jdk&oauth_version=1.0&size=original"
+      );
+      assert.equal(result, "GET&http%3A%2F%2Fphotos.example.net%2Fphotos&file%3Dvacation.jpg%26oauth_consumer_key%3Ddpf43f3p2l4k3l03%26oauth_nonce%3Dkllo9940pd9333jh%26oauth_signature_method%3DHMAC-SHA1%26oauth_timestamp%3D1191242096%26oauth_token%3Dnnch734d00sl2jdk%26oauth_version%3D1.0%26size%3Doriginal");
+    }
+  },
+  'When generating the signature with RSA-SHA1': {
+    topic: new OAuth(null, null, null, RsaPrivateKey, null, null, "RSA-SHA1"),
+    'we get a valid oauth signature': function (oa) {
+      var signatureBase = "GET&http%3A%2F%2Fphotos.example.net%2Fphotos&file%3Dvacation.jpg%26oauth_consumer_key%3Ddpf43f3p2l4k3l03%26oauth_nonce%3Dkllo9940pd9333jh%26oauth_signature_method%3DRSA-SHA1%26oauth_timestamp%3D1191242096%26oauth_token%3Dnnch734d00sl2jdk%26oauth_version%3D1.0%26size%3Doriginal";
+      var oauthSignature = oa._createSignature(signatureBase, "xyz4992k83j47x0b");
+      
+      assert.equal( oauthSignature, "qS4rhWog7GPgo4ZCJvUdC/1ZAax/Q4Ab9yOBvgxSopvmKUKp5rso+Zda46GbyN2hnYDTiA/g3P/d/YiPWa454BEBb/KWFV83HpLDIoqUUhJnlXX9MqRQQac0oeope4fWbGlfTdL2PXjSFJmvfrzybERD/ZufsFtVrQKS3QBpYiw=");
+      
+      //now check that given the public key we can verify this signature
+      var verifier = crypto.createVerify("RSA-SHA1").update(signatureBase);
+      var valid = verifier.verify(RsaPublicKey, oauthSignature, 'base64');
+      assert.ok( valid, "Signature could not be verified with RSA public key");
+    }
+  },
+  'When generating the signature base string with PLAINTEXT': {
+    topic: new OAuth(null, null, null, null, null, null, "PLAINTEXT"),
+    'we get the expected result string': function (oa) {
+      var result= oa._getSignature("GET", "http://photos.example.net/photos",
+                                   "file=vacation.jpg&oauth_consumer_key=dpf43f3p2l4k3l03&oauth_nonce=kllo9940pd9333jh&oauth_signature_method=PLAINTEXT&oauth_timestamp=1191242096&oauth_token=nnch734d00sl2jdk&oauth_version=1.0&size=original",
+                                   "test");
+      assert.equal( result, "&test");
+    }
+  },
+  'When normalising a url': {
+    topic: new OAuth(null, null, null, null, null, null, "HMAC-SHA1"),
+    'default ports should be stripped': function(oa) {
+      assert.equal( oa._normalizeUrl("https://somehost.com:443/foo/bar"), "https://somehost.com/foo/bar" );
+    },
+    'should leave in non-default ports from urls for use in signature generation': function(oa) {
+      assert.equal( oa._normalizeUrl("https://somehost.com:446/foo/bar"), "https://somehost.com:446/foo/bar" );
+      assert.equal( oa._normalizeUrl("http://somehost.com:81/foo/bar"), "http://somehost.com:81/foo/bar" );
+    },
+    'should add a trailing slash when no path at all is present': function(oa) {
+      assert.equal( oa._normalizeUrl("http://somehost.com"),  "http://somehost.com/")
+    }
+  },
+  'When making an array out of the arguments hash' : {
+    topic: new OAuth(null, null, null, null, null, null, "HMAC-SHA1"),
+    'flatten out arguments that are arrays' : function(oa) {
+      var parameters= {"z": "a",
+                       "a": ["1", "2"],
+                       "1": "c" };
+      var parameterResults= oa._makeArrayOfArgumentsHash(parameters);
+      assert.equal(parameterResults.length, 4);
+      assert.equal(parameterResults[0][0], "1");
+      assert.equal(parameterResults[1][0], "z");
+      assert.equal(parameterResults[2][0], "a");
+      assert.equal(parameterResults[3][0], "a");
+    }
+  },
+  'When ordering the request parameters'  : {
+    topic: new OAuth(null, null, null, null, null, null, "HMAC-SHA1"),
+    'Order them by name' : function(oa) {
+      var parameters= {"z": "a",
+                       "a": "b",
+                       "1": "c" };
+      var parameterResults= oa._sortRequestParams(oa._makeArrayOfArgumentsHash(parameters))
+      assert.equal(parameterResults[0][0], "1");
+      assert.equal(parameterResults[1][0], "a");
+      assert.equal(parameterResults[2][0], "z");
+    },
+    'If two parameter names are the same then order by the value': function(oa) {
+      var parameters= {"z": "a",
+                       "a": ["z", "b", "b", "a", "y"],
+                       "1": "c" };
+      var parameterResults= oa._sortRequestParams(oa._makeArrayOfArgumentsHash(parameters))
+      assert.equal(parameterResults[0][0], "1");
+      assert.equal(parameterResults[1][0], "a");
+      assert.equal(parameterResults[1][1], "a");
+      assert.equal(parameterResults[2][0], "a");
+      assert.equal(parameterResults[2][1], "b");
+      assert.equal(parameterResults[3][0], "a");
+      assert.equal(parameterResults[3][1], "b");
+      assert.equal(parameterResults[4][0], "a");
+      assert.equal(parameterResults[4][1], "y");
+      assert.equal(parameterResults[5][0], "a");
+      assert.equal(parameterResults[5][1], "z");
+      assert.equal(parameterResults[6][0], "z");
+    }
+  },
+  'When normalising the request parameters': {
+    topic: new OAuth(null, null, null, null, null, null, "HMAC-SHA1"),
+    'the resulting parameters should be encoded and ordered as per http://tools.ietf.org/html/rfc5849#section-3.1 (3.4.1.3.2)' : function(oa) {
+      var parameters= {"b5" : "=%3D",
+                       "a3": ["a", "2 q"],
+                       "c@": "",
+                       "a2": "r b",
+                       "oauth_consumer_key": "9djdj82h48djs9d2",
+                       "oauth_token":"kkk9d7dh3k39sjv7",
+                       "oauth_signature_method": "HMAC-SHA1",
+                       "oauth_timestamp": "137131201",
+                       "oauth_nonce": "7d8f3e4a",
+                       "c2" :  ""};
+      var normalisedParameterString= oa._normaliseRequestParams(parameters);
+      assert.equal(normalisedParameterString, "a2=r%20b&a3=2%20q&a3=a&b5=%3D%253D&c%40=&c2=&oauth_consumer_key=9djdj82h48djs9d2&oauth_nonce=7d8f3e4a&oauth_signature_method=HMAC-SHA1&oauth_timestamp=137131201&oauth_token=kkk9d7dh3k39sjv7");
+    }
+  },
+  'When preparing the parameters for use in signing': {
+    topic: new OAuth(null, null, null, null, null, null, "HMAC-SHA1"),
+    'We need to be wary of node\'s auto object creation from foo[bar] style url parameters' : function(oa) {
+      var result= oa._prepareParameters( "", "", "", "http://foo.com?foo[bar]=xxx&bar[foo]=yyy", {} );
+      assert.equal( result[0][0], "bar[foo]")
+      assert.equal( result[0][1], "yyy")
+      assert.equal( result[1][0], "foo[bar]")
+      assert.equal( result[1][1], "xxx")
+    }
+  },
+  'When signing a url': {
+    topic: function() {
+      var oa= new OAuth(null, null, "consumerkey", "consumersecret", "1.0", null, "HMAC-SHA1");
+      oa._getTimestamp= function(){ return "1272399856"; }
+      oa._getNonce= function(){ return "ybHPeOEkAUJ3k2wJT9Xb43MjtSgTvKqp"; }
+      return oa;
+    },
+    'Provide a valid signature when no token present': function(oa) {
+      assert.equal( oa.signUrl("http://somehost.com:3323/foo/poop?bar=foo"), "http://somehost.com:3323/foo/poop?bar=foo&oauth_consumer_key=consumerkey&oauth_nonce=ybHPeOEkAUJ3k2wJT9Xb43MjtSgTvKqp&oauth_signature_method=HMAC-SHA1&oauth_timestamp=1272399856&oauth_version=1.0&oauth_signature=7ytO8vPSLut2GzHjU9pn1SV9xjc%3D");
+    },
+    'Provide a valid signature when a token is present': function(oa) {
+      assert.equal( oa.signUrl("http://somehost.com:3323/foo/poop?bar=foo", "token"), "http://somehost.com:3323/foo/poop?bar=foo&oauth_consumer_key=consumerkey&oauth_nonce=ybHPeOEkAUJ3k2wJT9Xb43MjtSgTvKqp&oauth_signature_method=HMAC-SHA1&oauth_timestamp=1272399856&oauth_token=token&oauth_version=1.0&oauth_signature=9LwCuCWw5sURtpMroIolU3YwsdI%3D");
+    },
+    'Provide a valid signature when a token and a token secret is present': function(oa) {
+      assert.equal( oa.signUrl("http://somehost.com:3323/foo/poop?bar=foo", "token", "tokensecret"), "http://somehost.com:3323/foo/poop?bar=foo&oauth_consumer_key=consumerkey&oauth_nonce=ybHPeOEkAUJ3k2wJT9Xb43MjtSgTvKqp&oauth_signature_method=HMAC-SHA1&oauth_timestamp=1272399856&oauth_token=token&oauth_version=1.0&oauth_signature=zeOR0Wsm6EG6XSg0Vw%2FsbpoSib8%3D");
+    }
+  },
+  'When getting a request token': {
+    topic: function() {
+      var oa= new OAuth(null, null, "consumerkey", "consumersecret", "1.0", null, "HMAC-SHA1");
+      oa._getTimestamp= function(){ return "1272399856"; }
+      oa._getNonce= function(){ return "ybHPeOEkAUJ3k2wJT9Xb43MjtSgTvKqp"; }
+      oa._performSecureRequest= function(){ return this.requestArguments = arguments; }
+      return oa;
+    },
+    'Use the HTTP method in the client options': function(oa) {
+      oa.setClientOptions({ requestTokenHttpMethod: "GET" });
+      oa.getOAuthRequestToken(function() {}).nodeify(function() {
+        assert.equal(oa.requestArguments[2], "GET");
+      });
+    },
+    'Use a POST by default': function(oa) {
+      oa.setClientOptions({});
+      oa.getOAuthRequestToken(function() {}).nodeify(function() {
+        assert.equal(oa.requestArguments[2], "POST");
+      });
+    }
+  },
+  'When getting an access token': {
+    topic: function() {
+      var oa = new OAuth(null, null, "consumerkey", "consumersecret", "1.0", null, "HMAC-SHA1");
+      oa._getTimestamp = function() { return "1272399856"; };
+      oa._getNonce = function() { return "ybHPeOEkAUJ3k2wJT9Xb43MjtSgTvKqp"; };
+      oa._performSecureRequest= function() {
+        return this._oa.requestArguments = arguments;
+      };
+      return oa;
+    },
+    'Use the HTTP method in the client options': function(oa) {
+      oa.setClientOptions({ accessTokenHttpMethod: "GET" });
+      oa.getOAuthAccessToken(function() {}).nodeify(function() {
+        assert.equal(oa._oa.requestArguments[2], "GET");
+      });
+    },
+    'Use a POST by default': function(oa) {
+      oa.setClientOptions({});
+      oa.getOAuthAccessToken(function() {}).nodeify(function() {
+        assert.equal(oa._oa.requestArguments[2], "POST");
+      });
+    }
+  },
+  'When get authorization header' : {
+    topic: function() {
+      var oa= new OAuth(null, null, "consumerkey", "consumersecret", "1.0", null, "HMAC-SHA1");
+      oa._getTimestamp = function() { return "1272399856"; };
+      oa._getNonce = function() { return "ybHPeOEkAUJ3k2wJT9Xb43MjtSgTvKqp"; };
+      return oa;
+    },
+    'Provide a valid signature when a token and a token secret is present': function(oa) {
+      assert.equal( oa.authHeader("http://somehost.com:3323/foo/poop?bar=foo", "token", "tokensecret"), 'OAuth oauth_consumer_key="consumerkey",oauth_nonce="ybHPeOEkAUJ3k2wJT9Xb43MjtSgTvKqp",oauth_signature_method="HMAC-SHA1",oauth_timestamp="1272399856",oauth_token="token",oauth_version="1.0",oauth_signature="zeOR0Wsm6EG6XSg0Vw%2FsbpoSib8%3D"');
+    },
+    'Support variable whitespace separating the arguments': function(oa) {
+      oa._oauthParameterSeperator= ", ";
+      assert.equal( oa.authHeader("http://somehost.com:3323/foo/poop?bar=foo", "token", "tokensecret"), 'OAuth oauth_consumer_key="consumerkey", oauth_nonce="ybHPeOEkAUJ3k2wJT9Xb43MjtSgTvKqp", oauth_signature_method="HMAC-SHA1", oauth_timestamp="1272399856", oauth_token="token", oauth_version="1.0", oauth_signature="zeOR0Wsm6EG6XSg0Vw%2FsbpoSib8%3D"');
+    }
+  },
+  'When get the OAuth Echo authorization header': {
+    topic: function () {
+      var realm = "http://foobar.com/";
+      var verifyCredentials = "http://api.foobar.com/verify.json";
+      var oa = new OAuthEcho(realm, verifyCredentials, "consumerkey", "consumersecret", "1.0A", "HMAC-SHA1");
+      oa._getTimestamp= function(){ return "1272399856"; }
+      oa._getNonce= function(){ return "ybHPeOEkAUJ3k2wJT9Xb43MjtSgTvKqp"; }
+      return oa;
+    },
+    'Provide a valid signature when a token and token secret is present': function (oa) {
+      assert.equal( oa.authHeader("http://somehost.com:3323/foo/poop?bar=foo", "token", "tokensecret"), 'OAuth realm="http://foobar.com/",oauth_consumer_key="consumerkey",oauth_nonce="ybHPeOEkAUJ3k2wJT9Xb43MjtSgTvKqp",oauth_signature_method="HMAC-SHA1",oauth_timestamp="1272399856",oauth_token="token",oauth_version="1.0A",oauth_signature="0rr1LhSxACX2IEWRq3uCb4IwtOs%3D"');
+    }
+  },
+  'When non standard ports are used': {
+    topic: function() {
+      var oa= new OAuth(null, null, null, null, null, null, "HMAC-SHA1"),
+          mockProvider= {};
+
+      oa._createClient= function( port, hostname, method, path, headers, sshEnabled ) {
+        assert.equal(headers.Host, "somehost.com:8080");
+        assert.equal(hostname, "somehost.com");
+        assert.equal(port, "8080");
+        return {
+          on: function() {},
+          end: function() {}
+        };
+      }
+      return oa;
+    },
+    'getProtectedResource should correctly define the host headers': function(oa) {
+      oa.getProtectedResource("http://somehost.com:8080", "GET", "oauth_token", null, function(){})
+    }
+  },
+  'When building the OAuth Authorization header': {
+    topic: new OAuth(null, null, null, null, null, null, "HMAC-SHA1"),
+    'All provided oauth arguments should be concatentated correctly' : function(oa) {
+      var parameters= [
+        ["oauth_timestamp",         "1234567"],
+        ["oauth_nonce",             "ABCDEF"],
+        ["oauth_version",           "1.0"],
+        ["oauth_signature_method",  "HMAC-SHA1"],
+        ["oauth_consumer_key",      "asdasdnm2321b3"]];
+      assert.equal(oa._buildAuthorizationHeaders(parameters), 'OAuth oauth_timestamp="1234567",oauth_nonce="ABCDEF",oauth_version="1.0",oauth_signature_method="HMAC-SHA1",oauth_consumer_key="asdasdnm2321b3"');
+    },
+    '*Only* Oauth arguments should be concatentated, others should be disregarded' : function(oa) {
+      var parameters= [
+        ["foo",         "2343"],
+        ["oauth_timestamp",         "1234567"],
+        ["oauth_nonce",             "ABCDEF"],
+        ["bar",             "dfsdfd"],
+        ["oauth_version",           "1.0"],
+        ["oauth_signature_method",  "HMAC-SHA1"],
+        ["oauth_consumer_key",      "asdasdnm2321b3"],
+        ["foobar",      "asdasdnm2321b3"]];
+      assert.equal(oa._buildAuthorizationHeaders(parameters), 'OAuth oauth_timestamp="1234567",oauth_nonce="ABCDEF",oauth_version="1.0",oauth_signature_method="HMAC-SHA1",oauth_consumer_key="asdasdnm2321b3"');
+    },
+    '_buildAuthorizationHeaders should not depends on Array.prototype.toString' : function(oa) {
+      var _toString = Array.prototype.toString;
+      Array.prototype.toString = function(){ return '[Array] ' + this.length; }; // toString overwrite example used in jsdom.
+      var parameters= [
+        ["foo",         "2343"],
+        ["oauth_timestamp",         "1234567"],
+        ["oauth_nonce",             "ABCDEF"],
+        ["bar",             "dfsdfd"],
+        ["oauth_version",           "1.0"],
+        ["oauth_signature_method",  "HMAC-SHA1"],
+        ["oauth_consumer_key",      "asdasdnm2321b3"],
+        ["foobar",      "asdasdnm2321b3"]];
+      assert.equal(oa._buildAuthorizationHeaders(parameters), 'OAuth oauth_timestamp="1234567",oauth_nonce="ABCDEF",oauth_version="1.0",oauth_signature_method="HMAC-SHA1",oauth_consumer_key="asdasdnm2321b3"');
+      Array.prototype.toString = _toString;
+    }
+  },
+  'When performing the Secure Request' : {
+    topic: new OAuth("http://foo.com/RequestToken",
+                     "http://foo.com/AccessToken",
+                     "anonymous",  "anonymous",
+                     "1.0A", "http://foo.com/callback", "HMAC-SHA1"),
+    'using the POST method' : {
+      'Any passed extra_params should form part of the POST body': function(oa) {
+        var post_body_written= false;
+        var op= oa._createClient;
+        try {
+          oa._createClient= function( port, hostname, method, path, headers, sshEnabled ) {
+            return {
+              write: function(post_body){
+                post_body_written= true;
+                assert.equal(post_body,"scope=foobar%2C1%2C2");
+              }
+            };
+          }
+          oa._performSecureRequest("token", "token_secret", 'POST', 'http://foo.com/protected_resource', {"scope": "foobar,1,2"});
+          assert.equal(post_body_written, true);
+        }
+        finally {
+          oa._createClient= op;
+        }
+      }
+    }
+  },
+  'When performing a secure' : {
+    topic: new OAuth("http://foo.com/RequestToken",
+                     "http://foo.com/AccessToken",
+                     "anonymous",  "anonymous",
+                     "1.0A", "http://foo.com/callback", "HMAC-SHA1"),
+    'POST' : {
+      'if no callback is passed' : {
+        'it should return a request object': function(oa) {
+          var request= oa.post("http://foo.com/blah", "token", "token_secret", "BLAH", "text/plain")
+          assert.isObject(request);
+          assert.equal(request.method, "POST");
+          request.end();
+        }
+      },
+      'if a callback is passed' : {
+        "it should call the internal request's end method and return nothing": function(oa) {
+          var callbackCalled= false;
+          var op= oa._createClient;
+          try {
+            oa._createClient= function( port, hostname, method, path, headers, sshEnabled ) {
+              return {
+                write: function(){},
+                on: function() {},
+                end: function() {
+                  callbackCalled= true;
+                }
+              };
+            }
+            var request= oa.post("http://foo.com/blah", "token", "token_secret", "BLAH", "text/plain", function(e,d){})
+            assert.equal(callbackCalled, true);
+            assert.isUndefined(request);
+          }
+          finally {
+            oa._createClient= op;
+          }
+        }
+      },
+      'if the post_body is a buffer' : {
+        "It should be passed through as is, and the original content-type (if specified) should be passed through": function(oa) {
+          var op= oa._createClient;
+          try {
+            var callbackCalled= false;
+            oa._createClient= function( port, hostname, method, path, headers, sshEnabled ) {
+              assert.equal(headers["Content-Type"], "image/jpeg")
+              return {
+                write: function(data){
+                  callbackCalled= true;
+                  assert.equal(data.length, 4);
+                },
+                on: function() {},
+                end: function() {
+                }
+              };
+            };
+            var request= oa.post("http://foo.com/blah", "token", "token_secret", new Buffer([10,20,30,40]), "image/jpeg");
+            assert.equal(callbackCalled, true);
+          }
+          finally {
+            oa._createClient= op;
+          }
+        },
+        "It should be passed through as is, and no content-type is specified.": function(oa) {
+          //Should probably actually set application/octet-stream, but to avoid a change in behaviour
+          // will just document (here) that the library will set it to application/x-www-form-urlencoded
+          var op= oa._createClient;
+          try {
+            var callbackCalled= false;
+            oa._createClient= function( port, hostname, method, path, headers, sshEnabled ) {
+              assert.equal(headers["Content-Type"], "application/x-www-form-urlencoded");
+              return {
+                write: function(data){
+                  callbackCalled= true;
+                  assert.equal(data.length, 4);
+                },
+                on: function() {},
+                end: function() {
+                }
+              };
+            };
+            var request= oa.post("http://foo.com/blah", "token", "token_secret", new Buffer([10,20,30,40]));
+            assert.equal(callbackCalled, true);
+          }
+          finally {
+            oa._createClient= op;
+          }
+        }
+      },
+      'if the post_body is not a string or a buffer' : {
+        "It should be url encoded and the content type set to be x-www-form-urlencoded" : function(oa) {
+          var op= oa._createClient;
+          try {
+            var callbackCalled= false;
+            oa._createClient= function( port, hostname, method, path, headers, sshEnabled ) {
+              assert.equal(headers["Content-Type"], "application/x-www-form-urlencoded");
+              return {
+                write: function(data){
+                  callbackCalled= true;
+                  assert.equal(data, "foo=1%2C2%2C3&bar=1%2B2");
+                },
+                on: function() {},
+                end: function() {
+                }
+              };
+            };
+            var request= oa.post("http://foo.com/blah", "token", "token_secret", {"foo":"1,2,3", "bar":"1+2"});
+            assert.equal(callbackCalled, true);
+          }
+          finally {
+            oa._createClient= op;
+          }
+        }
+      },
+      'if the post_body is a string' : {
+        "and it contains non ascii (7/8bit) characters" : {
+          "the content length should be the byte count, and not the string length"  : function(oa) {
+            var testString= "Tôi yêu node";
+            var testStringLength= testString.length;
+            var testStringBytesLength= Buffer.byteLength(testString);
+            assert.notEqual(testStringLength, testStringBytesLength); // Make sure we're testing a string that differs between byte-length and char-length!
+
+            var op= oa._createClient;
+            try {
+              var callbackCalled= false;
+              oa._createClient= function( port, hostname, method, path, headers, sshEnabled ) {
+                assert.equal(headers["Content-length"], testStringBytesLength);
+                return {
+                  write: function(data){
+                    callbackCalled= true;
+                    assert.equal(data, testString);
+                  },
+                  on: function() {},
+                  end: function() {
+                  }
+                };
+              };
+              var request= oa.post("http://foo.com/blah", "token", "token_secret", "Tôi yêu node");
+              assert.equal(callbackCalled, true);
+            }
+            finally {
+              oa._createClient= op;
+            }
+          }
+        },
+        "and no post_content_type is specified" : {
+          "It should be written as is, with a content length specified, and the encoding should be set to be x-www-form-urlencoded" : function(oa) {
+            var op= oa._createClient;
+            try {
+              var callbackCalled= false;
+              oa._createClient= function( port, hostname, method, path, headers, sshEnabled ) {
+                assert.equal(headers["Content-Type"], "application/x-www-form-urlencoded");
+                assert.equal(headers["Content-length"], 23);
+                return {
+                  write: function(data){
+                    callbackCalled= true;
+                    assert.equal(data, "foo=1%2C2%2C3&bar=1%2B2");
+                  },
+                  on: function() {},
+                  end: function() {
+                  }
+                };
+              };
+              var request= oa.post("http://foo.com/blah", "token", "token_secret", "foo=1%2C2%2C3&bar=1%2B2");
+              assert.equal(callbackCalled, true);
+            }
+            finally {
+              oa._createClient= op;
+            }
+          }
+        },
+        "and a post_content_type is specified" : {
+          "It should be written as is, with a content length specified, and the encoding should be set to be as specified" : function(oa) {
+            var op= oa._createClient;
+            try {
+              var callbackCalled= false;
+              oa._createClient= function( port, hostname, method, path, headers, sshEnabled ) {
+                assert.equal(headers["Content-Type"], "unicorn/encoded");
+                assert.equal(headers["Content-length"], 23);
+                return {
+                  write: function(data){
+                    callbackCalled= true;
+                    assert.equal(data, "foo=1%2C2%2C3&bar=1%2B2");
+                  },
+                  on: function() {},
+                  end: function() {
+                  }
+                };
+              };
+              var request= oa.post("http://foo.com/blah", "token", "token_secret", "foo=1%2C2%2C3&bar=1%2B2", "unicorn/encoded");
+              assert.equal(callbackCalled, true);
+            }
+            finally {
+              oa._createClient= op;
+            }
+          }
+        }
+      }
+    },
+    'GET' : {
+      'if no callback is passed' : {
+        'it should return a request object': function(oa) {
+          var request= oa.get("http://foo.com/blah", "token", "token_secret");
+          assert.isObject(request);
+          assert.equal(request.method, "GET");
+          request.end();
+        }
+      },
+      'if a callback is passed' : {
+        "it should call the internal request's end method and return nothing": function(oa) {
+          var callbackCalled= false;
+          var op= oa._createClient;
+          try {
+            oa._createClient= function( port, hostname, method, path, headers, sshEnabled ) {
+              return {
+                on: function() {},
+                end: function() {
+                  callbackCalled= true;
+                }
+              };
+            };
+            var request= oa.get("http://foo.com/blah", "token", "token_secret", function(e,d) {});
+            assert.equal(callbackCalled, true);
+            assert.isUndefined(request);
+          }
+          finally {
+            oa._createClient= op;
+          }
+        }
+      },
+    },
+    'PUT' : {
+      'if no callback is passed' : {
+        'it should return a request object': function(oa) {
+          var request= oa.put("http://foo.com/blah", "token", "token_secret", "BLAH", "text/plain");
+          assert.isObject(request);
+          assert.equal(request.method, "PUT");
+          request.end();
+        }
+      },
+      'if a callback is passed' : {
+        "it should call the internal request's end method and return nothing": function(oa) {
+          var callbackCalled= 0;
+          var op= oa._createClient;
+          try {
+            oa._createClient= function( port, hostname, method, path, headers, sshEnabled ) {
+              return {
+                on: function() {},
+                write: function(data) {
+                  callbackCalled++;
+                },
+                end: function() {
+                  callbackCalled++;
+                }
+              };
+            };
+            var request= oa.put("http://foo.com/blah", "token", "token_secret", "BLAH", "text/plain", function(e,d){});
+            assert.equal(callbackCalled, 2);
+            assert.isUndefined(request);
+          }
+          finally {
+            oa._createClient= op;
+          }
+        }
+      },
+      'if the post_body is a buffer' : {
+        "It should be passed through as is, and the original content-type (if specified) should be passed through": function(oa) {
+          var op= oa._createClient;
+          try {
+            var callbackCalled= false;
+            oa._createClient= function( port, hostname, method, path, headers, sshEnabled ) {
+              assert.equal(headers["Content-Type"], "image/jpeg");
+              return {
+                write: function(data){
+                  callbackCalled= true;
+                  assert.equal(data.length, 4);
+                },
+                on: function() {},
+                end: function() {
+                }
+              };
+            };
+            var request= oa.put("http://foo.com/blah", "token", "token_secret", new Buffer([10,20,30,40]), "image/jpeg");
+            assert.equal(callbackCalled, true);
+          }
+          finally {
+            oa._createClient= op;
+          }
+        },
+        "It should be passed through as is, and no content-type is specified.": function(oa) {
+          //Should probably actually set application/octet-stream, but to avoid a change in behaviour
+          // will just document (here) that the library will set it to application/x-www-form-urlencoded
+          var op= oa._createClient;
+          try {
+            var callbackCalled= false;
+            oa._createClient= function( port, hostname, method, path, headers, sshEnabled ) {
+              assert.equal(headers["Content-Type"], "application/x-www-form-urlencoded");
+              return {
+                write: function(data){
+                  callbackCalled= true;
+                  assert.equal(data.length, 4);
+                },
+                on: function() {},
+                end: function() {
+                }
+              };
+            };
+            var request= oa.put("http://foo.com/blah", "token", "token_secret", new Buffer([10,20,30,40]));
+            assert.equal(callbackCalled, true);
+          }
+          finally {
+            oa._createClient= op;
+          }
+        }
+      },
+      'if the post_body is not a string' : {
+        "It should be url encoded and the content type set to be x-www-form-urlencoded" : function(oa) {
+          var op= oa._createClient;
+          try {
+            var callbackCalled= false;
+            oa._createClient= function( port, hostname, method, path, headers, sshEnabled ) {
+              assert.equal(headers["Content-Type"], "application/x-www-form-urlencoded");
+              return {
+                write: function(data) {
+                  callbackCalled= true;
+                  assert.equal(data, "foo=1%2C2%2C3&bar=1%2B2");
+                }
+              };
+            };
+            var request= oa.put("http://foo.com/blah", "token", "token_secret", {"foo":"1,2,3", "bar":"1+2"});
+            assert.equal(callbackCalled, true);
+          }
+          finally {
+            oa._createClient= op;
+          }
+        }
+      },
+      'if the post_body is a string' : {
+        "and no post_content_type is specified" : {
+          "It should be written as is, with a content length specified, and the encoding should be set to be x-www-form-urlencoded" : function(oa) {
+            var op= oa._createClient;
+            try {
+              var callbackCalled= false;
+              oa._createClient= function( port, hostname, method, path, headers, sshEnabled ) {
+                assert.equal(headers["Content-Type"], "application/x-www-form-urlencoded");
+                assert.equal(headers["Content-length"], 23);
+                return {
+                  write: function(data) {
+                    callbackCalled= true;
+                    assert.equal(data, "foo=1%2C2%2C3&bar=1%2B2");
+                  }
+                };
+              };
+              var request= oa.put("http://foo.com/blah", "token", "token_secret", "foo=1%2C2%2C3&bar=1%2B2");
+              assert.equal(callbackCalled, true);
+            }
+            finally {
+              oa._createClient= op;
+            }
+          }
+        },
+        "and a post_content_type is specified" : {
+          "It should be written as is, with a content length specified, and the encoding should be set to be as specified" : function(oa) {
+            var op= oa._createClient;
+            try {
+              var callbackCalled= false;
+              oa._createClient= function( port, hostname, method, path, headers, sshEnabled ) {
+                assert.equal(headers["Content-Type"], "unicorn/encoded");
+                assert.equal(headers["Content-length"], 23);
+                return {
+                  write: function(data) {
+                    callbackCalled= true;
+                    assert.equal(data, "foo=1%2C2%2C3&bar=1%2B2");
+                  }
+                };
+              };
+              var request= oa.put("http://foo.com/blah", "token", "token_secret", "foo=1%2C2%2C3&bar=1%2B2", "unicorn/encoded");
+              assert.equal(callbackCalled, true);
+            }
+            finally {
+              oa._createClient= op;
+            }
+          }
+        }
+      }
+    },
+    'DELETE' : {
+      'if no callback is passed' : {
+        'it should return a request object': function(oa) {
+          var request= oa.delete("http://foo.com/blah", "token", "token_secret");
+          assert.isObject(request);
+          assert.equal(request.method, "DELETE");
+          request.end();
+        }
+      },
+      'if a callback is passed' : {
+        "it should call the internal request's end method and return nothing": function(oa) {
+          var callbackCalled= false;
+          var op= oa._createClient;
+          try {
+            oa._createClient= function( port, hostname, method, path, headers, sshEnabled ) {
+              return {
+                on: function() {},
+                end: function() {
+                  callbackCalled= true;
+                }
+              };
+            };
+            var request= oa.delete("http://foo.com/blah", "token", "token_secret", function(e,d) {});
+            assert.equal(callbackCalled, true);
+            assert.isUndefined(request);
+          }
+          finally {
+            oa._createClient= op;
+          }
+        }
+      }
+    },
+    'Request With a Callback' : {
+      'and a 200 response code is received' : {
+        'it should callback successfully' : function(oa) {
+          var op= oa._createClient;
+          var callbackCalled = false;
+          try {
+            oa._createClient= function( port, hostname, method, path, headers, sshEnabled ) {
+              return new DummyRequest( new DummyResponse(200) );
+            };
+            oa._performSecureRequest("token", "token_secret", 'POST', 'http://originalurl.com', {"scope": "foobar,1,2"}, null, null, function(error) {
+              // callback
+              callbackCalled= true;
+              assert.equal(error, undefined);
+            });
+            assert.equal(callbackCalled, true);
+          }
+          finally {
+            oa._createClient= op;
+          }
+        }
+      },
+      'and a 210 response code is received' : {
+        'it should callback successfully' : function(oa) {
+          var op= oa._createClient;
+          var callbackCalled = false;
+          try {
+            oa._createClient= function( port, hostname, method, path, headers, sshEnabled ) {
+              return new DummyRequest( new DummyResponse(210) );
+            };
+            oa._performSecureRequest("token", "token_secret", 'POST', 'http://originalurl.com', {"scope": "foobar,1,2"}, null, null, function(error) {
+              // callback
+              callbackCalled= true;
+              assert.equal(error, undefined);
+            });
+            assert.equal(callbackCalled, true);
+          }
+          finally {
+            oa._createClient= op;
+          }
+        }
+      },
+      'And A 301 redirect is received' : {
+        'and there is a location header' : {
+          'it should (re)perform the secure request but with the new location' : function(oa) {
+            var op= oa._createClient;
+            var psr= oa._performSecureRequest;
+            var responseCounter = 1;
+            var callbackCalled = false;
+            var DummyResponse =function() {
+              if( responseCounter == 1 ){
+                this.statusCode= 301;
+                this.headers= {location:"http://redirectto.com"};
+                responseCounter++;
+              }
+              else {
+                this.statusCode= 200;
+              }
+            };
+            DummyResponse.prototype= events.EventEmitter.prototype;
+            DummyResponse.prototype.setEncoding= function() {};
+
+            try {
+              oa._createClient= function( port, hostname, method, path, headers, sshEnabled ) {
+                return new DummyRequest( new DummyResponse() );
+              };
+              oa._performSecureRequest= function( oauth_token, oauth_token_secret, method, url, extra_params, post_body, post_content_type,  callback ) {
+                if( responseCounter == 1 ) {
+                  assert.equal(url, "http://originalurl.com");
+                }
+                else {
+                  assert.equal(url, "http://redirectto.com");
+                }
+                return psr.call(oa, oauth_token, oauth_token_secret, method, url, extra_params, post_body, post_content_type,  callback );
+              };
+
+              oa._performSecureRequest("token", "token_secret", 'POST', 'http://originalurl.com', {"scope": "foobar,1,2"}, null, null, function() {
+                // callback
+                assert.equal(responseCounter, 2);
+                callbackCalled= true;
+              });
+              assert.equal(callbackCalled, true);
+            }
+            finally {
+              oa._createClient= op;
+              oa._performSecureRequest= psr;
+            }
+          }
+        },
+        'but there is no location header' : {
+          'it should execute the callback, passing the HTTP Response code' : function(oa) {
+            var op= oa._createClient;
+            var callbackCalled = false;
+            try {
+              oa._createClient= function( port, hostname, method, path, headers, sshEnabled ) {
+                return new DummyRequest( new DummyResponse(301) );
+              };
+              oa._performSecureRequest("token", "token_secret", 'POST', 'http://originalurl.com', {"scope": "foobar,1,2"}, null, null, function(error) {
+                // callback
+                assert.equal(error.statusCode, 301);
+                callbackCalled= true;
+              });
+              assert.equal(callbackCalled, true);
+            }
+            finally {
+              oa._createClient= op;
+            }
+          }
+        },
+        'and followRedirect is true' : {
+          'it should (re)perform the secure request but with the new location' : function(oa) {
+            var op= oa._createClient;
+            var psr= oa._performSecureRequest;
+            var responseCounter = 1;
+            var callbackCalled = false;
+            var DummyResponse =function() {
+              if( responseCounter == 1 ){
+                this.statusCode= 301;
+                this.headers= {location:"http://redirectto.com"};
+                responseCounter++;
+              }
+              else {
+                this.statusCode= 200;
+              }
+            };
+            DummyResponse.prototype= events.EventEmitter.prototype;
+            DummyResponse.prototype.setEncoding = function() {};
+
+            try {
+              oa._createClient= function( port, hostname, method, path, headers, sshEnabled ) {
+                return new DummyRequest( new DummyResponse() );
+              };
+              oa._performSecureRequest= function( oauth_token, oauth_token_secret, method, url, extra_params, post_body, post_content_type,  callback ) {
+                if( responseCounter == 1 ) {
+                  assert.equal(url, "http://originalurl.com");
+                }
+                else {
+                  assert.equal(url, "http://redirectto.com");
+                }
+                return psr.call(oa, oauth_token, oauth_token_secret, method, url, extra_params, post_body, post_content_type,  callback );
+              };
+
+              oa._performSecureRequest("token", "token_secret", 'POST', 'http://originalurl.com', {"scope": "foobar,1,2"}, null, null, function() {
+                // callback
+                assert.equal(responseCounter, 2);
+                callbackCalled= true;
+              });
+              assert.equal(callbackCalled, true)
+            }
+            finally {
+              oa._createClient= op;
+              oa._performSecureRequest= psr;
+            }
+          }
+        },
+        'and followRedirect is false' : {
+          'it should not perform the secure request with the new location' : function(oa) {
+            var op= oa._createClient;
+            oa.setClientOptions({ followRedirects: false });
+            var DummyResponse =function() {
+              this.statusCode= 301;
+              this.headers= {location:"http://redirectto.com"};
+            }
+            DummyResponse.prototype= events.EventEmitter.prototype;
+            DummyResponse.prototype.setEncoding= function() {}
+
+            try {
+              oa._createClient= function( port, hostname, method, path, headers, sshEnabled ) {
+                return new DummyRequest( new DummyResponse() );
+              }
+              oa._performSecureRequest("token", "token_secret", 'POST', 'http://originalurl.com', {"scope": "foobar,1,2"}, null, null, function(res, data, response) {
+                // callback
+                assert.equal(res.statusCode, 301);
+              });
+            }
+            finally {
+              oa._createClient= op;
+              oa.setClientOptions({followRedirects:true});
+            }
+          }
+        }
+      },
+      'And A 302 redirect is received' : {
+        'and there is a location header' : {
+          'it should (re)perform the secure request but with the new location' : function(oa) {
+            var op= oa._createClient;
+            var psr= oa._performSecureRequest;
+            var responseCounter = 1;
+            var callbackCalled = false;
+            var DummyResponse =function() {
+              if( responseCounter == 1 ){
+                this.statusCode= 302;
+                this.headers= {location:"http://redirectto.com"};
+                responseCounter++;
+              } else {
+                this.statusCode= 200;
+              }
+            };
+            DummyResponse.prototype= events.EventEmitter.prototype;
+            DummyResponse.prototype.setEncoding = function() {};
+
+            try {
+              oa._createClient= function( port, hostname, method, path, headers, sshEnabled ) {
+                return new DummyRequest( new DummyResponse() );
+              }
+              oa._performSecureRequest= function( oauth_token, oauth_token_secret, method, url, extra_params, post_body, post_content_type,  callback ) {
+                if( responseCounter == 1 ) {
+                  assert.equal(url, "http://originalurl.com");
+                } else {
+                  assert.equal(url, "http://redirectto.com");
+                }
+                return psr.call(oa, oauth_token, oauth_token_secret, method, url, extra_params, post_body, post_content_type,  callback )
+              }
+
+              oa._performSecureRequest("token", "token_secret", 'POST', 'http://originalurl.com', {"scope": "foobar,1,2"}, null, null, function() {
+                // callback
+                assert.equal(responseCounter, 2);
+                callbackCalled = true;
+              });
+              assert.equal(callbackCalled, true);
+            }
+            finally {
+              oa._createClient= op;
+              oa._performSecureRequest= psr;
+            }
+          }
+        },
+        'but there is no location header' : {
+          'it should execute the callback, passing the HTTP Response code' : function(oa) {
+            var op= oa._createClient;
+            var callbackCalled = false;
+            try {
+              oa._createClient = function(port, hostname, method, path, headers, sshEnabled ) {
+                return new DummyRequest(new DummyResponse(302));
+              };
+              oa._performSecureRequest("token", "token_secret", 'POST', 'http://originalurl.com', {"scope": "foobar,1,2"}, null, null, function(error) {
+                // callback
+                assert.equal(error.statusCode, 302);
+                callbackCalled = true;
+              });
+              assert.equal(callbackCalled, true);
+            }
+            finally {
+              oa._createClient= op;
+            }
+          }
+        },
+        'and followRedirect is true' : {
+          'it should (re)perform the secure request but with the new location' : function(oa) {
+            var op= oa._createClient;
+            var psr= oa._performSecureRequest;
+            var responseCounter = 1;
+            var callbackCalled = false;
+            var DummyResponse = function() {
+              if (responseCounter == 1) {
+                this.statusCode= 302;
+                this.headers= {location:"http://redirectto.com"};
+                responseCounter++;
+              } else {
+                this.statusCode= 200;
+              }
+            };
+            DummyResponse.prototype= events.EventEmitter.prototype;
+            DummyResponse.prototype.setEncoding = function() {};
+
+            try {
+              oa._createClient = function(port, hostname, method, path, headers, sshEnabled) {
+                return new DummyRequest(new DummyResponse());
+              };
+              oa._performSecureRequest = function(oauth_token, oauth_token_secret, method, url, extra_params, post_body, post_content_type,  callback) {
+                if (responseCounter == 1) {
+                  assert.equal(url, "http://originalurl.com");
+                } else {
+                  assert.equal(url, "http://redirectto.com");
+                }
+                return psr.call(oa, oauth_token, oauth_token_secret, method, url, extra_params, post_body, post_content_type, callback);
+              };
+
+              oa._performSecureRequest("token", "token_secret", 'POST', 'http://originalurl.com', {"scope": "foobar,1,2"}, null, null, function() {
+                // callback
+                assert.equal(responseCounter, 2);
+                callbackCalled = true;
+              });
+              assert.equal(callbackCalled, true);
+            }
+            finally {
+              oa._createClient= op;
+              oa._performSecureRequest= psr;
+            }
+          }
+        },
+        'and followRedirect is false' : {
+          'it should not perform the secure request with the new location' : function(oa) {
+            var op= oa._createClient;
+            oa.setClientOptions({ followRedirects: false });
+            var DummyResponse =function() {
+              this.statusCode= 302;
+              this.headers= {location:"http://redirectto.com"};
+            };
+            DummyResponse.prototype= events.EventEmitter.prototype;
+            DummyResponse.prototype.setEncoding= function() {};
+
+            try {
+              oa._createClient= function( port, hostname, method, path, headers, sshEnabled ) {
+                return new DummyRequest( new DummyResponse() );
+              };
+              oa._performSecureRequest("token", "token_secret", 'POST', 'http://originalurl.com', {"scope": "foobar,1,2"}, null, null, function(res, data, response) {
+                // callback
+                assert.equal(res.statusCode, 302);
+              });
+            }
+            finally {
+              oa._createClient= op;
+              oa.setClientOptions({followRedirects:true});
+            }
+          }
+        }
+      }
+    }
+  }
+}).export(module);

--- a/tests/oauthpromise-tests.js
+++ b/tests/oauthpromise-tests.js
@@ -893,20 +893,20 @@ vows.describe('OAuth').addBatch({
             }
           }
         },
-        'and followRedirect is false' : {
-          'it should not perform the secure request with the new location' : function(oa) {
+        'and followRedirect is false': {
+          'it should not perform the secure request with the new location': function(oa) {
             var op = oa._oa._createClient;
             oa.setClientOptions({ followRedirects: false });
-            var DummyResponse =function() {
-              this.statusCode= 301;
-              this.headers= {location:"http://redirectto.com"};
+            var DummyResponse = function() {
+              this.statusCode = 301;
+              this.headers = { location: 'http://redirectto.com' };
             };
-            DummyResponse.prototype= events.EventEmitter.prototype;
-            DummyResponse.prototype.setEncoding= function() {};
+            DummyResponse.prototype = events.EventEmitter.prototype;
+            DummyResponse.prototype.setEncoding = function() {};
 
             try {
-                return new DummyRequest( new DummyResponse() );
               oa._oa._createClient = function(port, hostname, method, path, headers, sshEnabled) {
+                return new DummyRequest(new DummyResponse());
               };
               oa._oa._performSecureRequest('token', 'token_secret', 'POST', 'http://originalurl.com', { 'scope': 'foobar,1,2' }, null, null, function(res, data, response) {
                 assert.equal(res.statusCode, 301);

--- a/tests/oauthpromise-tests.js
+++ b/tests/oauthpromise-tests.js
@@ -895,7 +895,7 @@ vows.describe('OAuth').addBatch({
         },
         'and followRedirect is false' : {
           'it should not perform the secure request with the new location' : function(oa) {
-            var op= oa._createClient;
+            var op = oa._oa._createClient;
             oa.setClientOptions({ followRedirects: false });
             var DummyResponse =function() {
               this.statusCode= 301;
@@ -905,14 +905,14 @@ vows.describe('OAuth').addBatch({
             DummyResponse.prototype.setEncoding= function() {};
 
             try {
-              oa._createClient= function( port, hostname, method, path, headers, sshEnabled ) {
                 return new DummyRequest( new DummyResponse() );
+              oa._oa._createClient = function(port, hostname, method, path, headers, sshEnabled) {
               };
-              oa._performSecureRequest("token", "token_secret", 'POST', 'http://originalurl.com', { "scope": "foobar,1,2" }, null, null, function(res, data, response) {
+              oa._oa._performSecureRequest('token', 'token_secret', 'POST', 'http://originalurl.com', { 'scope': 'foobar,1,2' }, null, null, function(res, data, response) {
                 assert.equal(res.statusCode, 301);
               });
             } finally {
-              oa._createClient = op;
+              oa._oa._createClient = op;
               oa.setClientOptions({ followRedirects: true });
             }
           }

--- a/tests/shared.js
+++ b/tests/shared.js
@@ -1,26 +1,31 @@
 var events = require('events');
 
-exports.DummyResponse = function( statusCode ) {
-    this.statusCode= statusCode;
-    this.headers= {};
-}
-exports.DummyResponse.prototype= events.EventEmitter.prototype;
-exports.DummyResponse.prototype.setEncoding= function() {}
+exports.DummyResponse = function(statusCode) {
+  this.statusCode = statusCode;
+  this.headers = {};
+};
 
-exports.DummyRequest =function( response ) {
-  this.response=  response;
-  this.responseSent= false;
-}
-exports.DummyRequest.prototype= events.EventEmitter.prototype;
-exports.DummyRequest.prototype.write= function(post_body){}
-exports.DummyRequest.prototype.write= function(post_body){
-  this.responseSent= true;
-  this.emit('response',this.response);
-}
-exports.DummyRequest.prototype.end= function(){
-  if(!this.responseSent) {
-    this.responseSent= true;
+exports.DummyResponse.prototype = events.EventEmitter.prototype;
+
+exports.DummyResponse.prototype.setEncoding = function() {
+};
+
+exports.DummyRequest = function(response) {
+  this.response = response;
+  this.responseSent = false;
+};
+
+exports.DummyRequest.prototype = events.EventEmitter.prototype;
+
+exports.DummyRequest.prototype.write = function(postBody) {
+  this.responseSent = true;
+  this.emit('response', this.response);
+};
+
+exports.DummyRequest.prototype.end = function() {
+  if (!this.responseSent) {
+    this.responseSent = true;
     this.emit('response',this.response);
   }
   this.response.emit('end');
-}
+};


### PR DESCRIPTION
* OAuth Promises
* OAuth2 Promises
* Examples that use promises
* Existing tests for OAuth and OAuth2 ported to ensure backwards compatibility with Promise wrapper objects

## Notes

Some more testing is definitely needed because I have a feeling we will need custom wrappers for the post/get/put requests in OAuth to make sure the promises are receiving the right objects. For example in OAuth2 Promises the first `then` receiver will receive just the data from the response, but in OAuth2 something else may happen such as receiving the request and response object. The node-oauth API for callbacks always passes `accessToken`, `refreshToken` and `response` which we aren't conforming too.