### PR TITLE
Handle multiple params of the same name properly

### DIFF
--- a/lib/oauth.js
+++ b/lib/oauth.js
@@ -170,6 +170,15 @@ exports.OAuth.prototype._sortRequestParams= function(argument_pairs) {
 
 exports.OAuth.prototype._normaliseRequestParams= function(args) {
   var argument_pairs= this._makeArrayOfArgumentsHash(args);
+
+  // Handle multiple query params of the same name.
+  // We need to replace 'param[N]' with just 'param'.
+  for (var i=0; i<argument_pairs.length; i++) {
+    if (argument_pairs[i][0].search(/\[\d\]/) != -1) {
+      argument_pairs[i] = [argument_pairs[i][0].replace(/\[\d\]/,''), argument_pairs[i][1]];
+    }
+  }
+
   // First encode them #3.4.1.3.2 .1
   for(var i=0;i<argument_pairs.length;i++) {
     argument_pairs[i][0]= this._encodeData( argument_pairs[i][0] );


### PR DESCRIPTION
In case we try to call `consumer.get('URL?param=1&param=2')`, the library
generates incorrect URL. That is because it internally parses the URL so
that the params are actually called `param[0]` and `param[1]`.

This patch fixed the param names so that the resulting URL is actually
including `param=1` and `param=2`.

This is what was proposed in #71 and it fixes #71 .
