### PR TITLE
Omit client_secret parameter when it is empty

### DIFF
--- a/lib/oauth2.js
+++ b/lib/oauth2.js
@@ -163,7 +163,8 @@ exports.OAuth2.prototype.getAuthorizeUrl= function( params ) {
 exports.OAuth2.prototype.getOAuthAccessToken= function(code, params, callback) {
   var params= params || {};
   params['client_id'] = this._clientId;
-  params['client_secret'] = this._clientSecret;
+  if ( this._clientSecret )
+    params['client_secret'] = this._clientSecret;
   var codeParam = (params.grant_type === 'refresh_token') ? 'refresh_token' : 'code';
   params[codeParam]= code;
 


### PR DESCRIPTION
According to :

https://tools.ietf.org/html/rfc6749#section-2.3.1

     client_secret
           REQUIRED.  The client secret.  The client MAY omit the
           parameter if the client secret is an empty string.

In some cases, like using JWT or other assertion approach as secret, this parameter in request should be removed.