### PR TITLE
Allow setting https options

### DIFF
--- a/lib/oauth.js
+++ b/lib/oauth.js
@@ -253,8 +253,17 @@ exports.OAuth.prototype._createClient= function( port, hostname, method, path, h
   } else {
     httpModel= http;
   }
+
+  for( var k in this._httpOptions ) {
+     options[k]=  this._httpOptions[k];
+  }
+
   return httpModel.request(options);
 }
+
+exports.OAuth.prototype.setHttpOptions = function(options) {
+  this._httpOptions = options;
+};
 
 exports.OAuth.prototype._prepareParameters= function( oauth_token, oauth_token_secret, method, url, extra_params ) {
   var oauthParameters= {


### PR DESCRIPTION
This is a subset of changes in https://github.com/ciaranj/node-oauth/pull/206 - it just allows setting custom settings like certificate and CA. I decided to go for a subset as it is simple and safe enough to be merged...
