### PR TITLE
examples/twitter: guard against undefined handlers

### DIFF
--- a/examples/twitter-example.js
+++ b/examples/twitter-example.js
@@ -69,6 +69,7 @@ http.createServer(function (request, response) {
 
             }
         };
+      if (typeof handlers[urlObj.pathname] === 'function')
         handlers[urlObj.pathname](request, response);
     })
 


### PR DESCRIPTION
Most browsers automatically make a request to `/favicon.ico`, and since
`handlers['/favicon.ico']` is not a function that crashes the example app.
