### PR TITLE
examples/twitter: variable typo

### DIFF
--- a/examples/twitter-example.js
+++ b/examples/twitter-example.js
@@ -50,7 +50,7 @@ http.createServer(function (request, response) {
                            function (error, twitterResponseData, result) {
                                if (error) {
                                    console.log(error)
-                                   res.end(JSON.stringify(error));
+                                   response.end(JSON.stringify(error));
                                    return;
                                }
                                try {


### PR DESCRIPTION
`res` is undefined.
