### PR TITLE
feat: add ability to include key and certificate

### DIFF
--- a/lib/oauth.js
+++ b/lib/oauth.js
@@ -6,13 +6,15 @@ var crypto= require('crypto'),
     querystring= require('querystring'),
     OAuthUtils= require('./_utils');
 
-exports.OAuth= function(requestUrl, accessUrl, consumerKey, consumerSecret, version, authorize_callback, signatureMethod, nonceSize, customHeaders) {
+exports.OAuth= function(requestUrl, accessUrl, consumerKey, consumerSecret, version, authorize_callback, signatureMethod, nonceSize, customHeaders, certificate, privateKey) {
   this._isEcho = false;
 
   this._requestUrl= requestUrl;
   this._accessUrl= accessUrl;
   this._consumerKey= consumerKey;
   this._consumerSecret= this._encodeData( consumerSecret );
+  this._certificate = certificate;
+  this._privateKey = privateKey;
   if (signatureMethod == "RSA-SHA1") {
     this._privateKey = consumerSecret;
   }
@@ -248,6 +250,14 @@ exports.OAuth.prototype._createClient= function( port, hostname, method, path, h
     headers: headers
   };
   var httpModel;
+
+  if ( this._privateKey ) {
+    options.key = this._privateKey;
+  }
+  if ( this._certificate ) {
+    options.cert = this._certificate;
+  }
+
   if( sslEnabled ) {
     httpModel= https;
   } else {


### PR DESCRIPTION
when initialising oauth, then use those with the request if required by the provider