### PR TITLE
Remove content-type from GET requests

### DIFF
--- a/lib/oauth.js
+++ b/lib/oauth.js
@@ -358,8 +358,10 @@ exports.OAuth.prototype._performSecureRequest= function( oauth_token, oauth_toke
   } else {
       headers["Content-length"]= 0;
   }
-
-  headers["Content-Type"]= post_content_type;
+  
+  if (method != "GET"){
+    headers["Content-Type"]= post_content_type;
+  }
 
   var path;
   if( !parsedUrl.pathname  || parsedUrl.pathname == "" ) parsedUrl.pathname ="/";


### PR DESCRIPTION
The content type is unsettable from oauth.get requests so it ends up being "application/x-www-form-urlencoded". I'm trying to access a rest endpoint and this content-type is causing a 415 error "Unsupported Media Type".