### PR TITLE
Support post data on PATCH requests in OAuth2

### DIFF
--- a/lib/oauth2.js
+++ b/lib/oauth2.js
@@ -148,7 +148,7 @@ exports.OAuth2.prototype._executeRequest= function( http_library, options, post_
     callback(e);
   });
 
-  if( (options.method == 'POST' || options.method == 'PUT') && post_body ) {
+  if( ['POST','PUT','PATCH'].indexOf(options.method) > -1 && post_body ) {
      request.write(post_body);
   }
   request.end();


### PR DESCRIPTION
Some OAuth2-enabled APIs use the `PATCH` HTTP verb (for example [GitHub's API](https://developer.github.com/v3/#http-verbs)) combined with a body to update an existing resource.

This one-line change makes it possible to use `oauth2`'s `_request` call to send a `PATCH` request with such a body. @ciaranj please take a look.