### PR TITLE
Don't delete 'refresh_token' from 'results'

### DIFF
--- a/lib/oauth2.js
+++ b/lib/oauth2.js
@@ -191,7 +191,6 @@ exports.OAuth2.prototype.getOAuthAccessToken= function(code, params, callback) {
       }
       var access_token= results["access_token"];
       var refresh_token= results["refresh_token"];
-      delete results["refresh_token"];
       callback(null, access_token, refresh_token, results); // callback results =-=
     }
   });


### PR DESCRIPTION
Don't delete the `refresh_token` (or anything for that matter) from the `results` object returned from `OAuth2.getOAuthAccessToken`. Everything sent back should be in the `results` for those that want to save it all from there.