### PR TITLE
Adding ability to specify an agent for OAuth2 requests

### DIFF
--- a/lib/oauth2.js
+++ b/lib/oauth2.js
@@ -15,7 +15,16 @@ exports.OAuth2= function(clientId, clientSecret, baseSite, authorizePath, access
   this._authMethod= "Bearer";
   this._customHeaders = customHeaders || {};
   this._useAuthorizationHeaderForGET= false;
-}
+
+  //our agent
+  this._agent = undefined;
+};
+
+// Allows you to set an agent to use instead of the default HTTP or
+// HTTPS agents. Useful when dealing with your own certificates.
+exports.OAuth2.prototype.setAgent = function(agent) {
+  this._agent = agent;
+};
 
 // This 'hack' method is required for sites that don't use
 // 'access_token' as the name of the access token (for requests).
@@ -128,6 +137,11 @@ exports.OAuth2.prototype._executeRequest= function( http_library, options, post_
   }
 
   var result= "";
+
+  //set the agent on the request options
+  if (this._agent) {
+    options.agent = this._agent;
+  }
 
   var request = http_library.request(options);
   request.on('response', function (response) {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 { "name" : "oauth"
 , "description" : "Library for interacting with OAuth 1.0, 1.0A, 2 and Echo.  Provides simplified client access and allows for construction of more complex apis and OAuth providers."
-, "version" : "0.9.14"
+, "version" : "0.9.15"
 , "directories" : { "lib" : "./lib" }
 , "main" : "index.js"
 , "author" : "Ciaran Jessup <ciaranj@gmail.com>"

--- a/tests/oauth2tests.js
+++ b/tests/oauth2tests.js
@@ -286,5 +286,19 @@ vows.describe('OAuth2').addBatch({
           oa.get("", {});
         }
       }
+    },
+    'When specifying an agent, that agent is passed to the HTTP request method' : {
+      topic : new OAuth2('clientId', 'clientSecret', undefined, undefined, undefined, undefined),
+      'When calling _executeRequest': {
+        'we whould see the agent being put into the options' : function(oa) {
+          oa.setAgent('awesome agent');
+          oa._executeRequest({
+            request : function(options, cb) {
+              assert.equal(options.agent, 'awesome agent');
+              return new DummyRequest(new DummyResponse(200));
+            }
+          }, {}, null, function() {});
+        }
+      }
     }
 }).export(module);


### PR DESCRIPTION
I've added a new private property (_agent) and a public method to set this property on the OAuth2 object.

When this property is set is it passed into the http_library.request method within the options, allowing you to override the default globalAgent when carrying out OAuth2 requests.

I've added test coverage to ensure that the property gets set and passed into the request method.

Also I incremented the version number because optimism :)