### PR TITLE
Enable differing domains for OAuth 2 requests

### DIFF
--- a/lib/oauth2.js
+++ b/lib/oauth2.js
@@ -49,7 +49,7 @@ exports.OAuth2.prototype.useAuthorizationHeaderforGET = function(useIt) {
 }
 
 exports.OAuth2.prototype._getAccessTokenUrl= function() {
-  return this._baseSite + this._accessTokenUrl; /* + "?" + querystring.stringify(params); */
+  return this._accessTokenUrl; /* + "?" + querystring.stringify(params); */
 }
 
 // Build the authorization header. In particular, build the part after the colon.
@@ -68,6 +68,9 @@ exports.OAuth2.prototype._chooseHttpLibrary= function( parsedUrl ) {
 };
 
 exports.OAuth2.prototype._request= function(method, url, headers, post_body, access_token, callback) {
+  if( !url.match(/^https?:/) ) {
+    url = this._baseSite + url;
+  }
 
   var parsedUrl= URL.parse( url, true );
   if( parsedUrl.protocol == "https:" && !parsedUrl.port ) {
@@ -171,7 +174,7 @@ exports.OAuth2.prototype._executeRequest= function( http_library, options, post_
 exports.OAuth2.prototype.getAuthorizeUrl= function( params ) {
   var params= params || {};
   params['client_id'] = this._clientId;
-  return this._baseSite + this._authorizeUrl + "?" + querystring.stringify(params);
+  return this._authorizeUrl + "?" + querystring.stringify(params);
 }
 
 exports.OAuth2.prototype.getOAuthAccessToken= function(code, params, callback) {


### PR DESCRIPTION
This solves #313 by only prepending `this._baseSite` to URLs if they don't start with `/https?:/`.