### PR TITLE
fix: prevent double callback in _executeRequest

### DIFF
--- a/lib/oauth2.js
+++ b/lib/oauth2.js
@@ -158,8 +158,13 @@ exports.OAuth2.prototype._executeRequest= function( http_library, options, post_
     });
   });
   request.on('error', function(e) {
-    callbackCalled= true;
-    callback(e);
+    // `www.googleapis.com` does `ECONNRESET` just after data is received in `passBackControl`
+    // this prevents the callback from being called twice, first in passBackControl and second time in here
+    // see also NodeJS Stream documentation: "The 'error' event may be emitted by a Readable implementation at any time"
+    if(!callbackCalled) {
+      callbackCalled= true;
+      callback(e);
+    }
   });
 
   if( (options.method == 'POST' || options.method == 'PUT') && post_body ) {


### PR DESCRIPTION
`www.googleapis.com` does `ECONNRESET` just after data is received in `passBackControl`

This prevents the callback from being called twice.