### PR TITLE
Changes for Tiktok Compatibility

### DIFF
--- a/lib/oauth2.js
+++ b/lib/oauth2.js
@@ -175,13 +175,13 @@ exports.OAuth2.prototype._executeRequest= function( http_library, options, post_
 
 exports.OAuth2.prototype.getAuthorizeUrl= function( params ) {
   var params= params || {};
-  params['client_id'] = this._clientId;
+  if(!params['client_key']) params['client_id'] = this._clientId;
   return this._baseSite + this._authorizeUrl + "?" + querystring.stringify(params);
 }
 
 exports.OAuth2.prototype.getOAuthAccessToken= function(code, params, callback) {
   var params= params || {};
-  params['client_id'] = this._clientId;
+  if(!params['client_key']) params['client_id'] = this._clientId;
   params['client_secret'] = this._clientSecret;
   var codeParam = (params.grant_type === 'refresh_token') ? 'refresh_token' : 'code';
   params[codeParam]= code;

--- a/lib/oauth2.js
+++ b/lib/oauth2.js
@@ -175,7 +175,6 @@ exports.OAuth2.prototype._executeRequest= function( http_library, options, post_
 
 exports.OAuth2.prototype.getAuthorizeUrl= function( params ) {
   var params= params || {};
-  if(!params['client_key']) params['client_id'] = this._clientId;
   return this._baseSite + this._authorizeUrl + "?" + querystring.stringify(params);
 }
 


### PR DESCRIPTION
Tiktok Provider asks for a client_key instead of a client_id, so in order to make this usable i needed to add two lines of codes