### PR TITLE
Add lib dir to published files

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,5 +17,8 @@
     "scripts": {
         "test": "make test"
     },
+    "files": [
+        "/lib/**"
+    ],
     "license": "MIT"
 }


### PR DESCRIPTION
This PR adds `/lib/` directory into list of published files. What excludes any other files except of mandatory to be included into a package.

This change reduces overall package size from 130Kb to 49Kb.