### PR TITLE
added support for HMAC-SHA256

### DIFF
--- a/lib/oauth.js
+++ b/lib/oauth.js
@@ -24,7 +24,7 @@ exports.OAuth= function(requestUrl, accessUrl, consumerKey, consumerSecret, vers
     this._authorize_callback= authorize_callback;
   }
 
-  if( signatureMethod != "PLAINTEXT" && signatureMethod != "HMAC-SHA1" && signatureMethod != "RSA-SHA1")
+  if( signatureMethod != "PLAINTEXT" && signatureMethod != "HMAC-SHA1" && signatureMethod != "HMAC-SHA256" && signatureMethod != "RSA-SHA1")
     throw new Error("Un-supported signature method: " + signatureMethod )
   this._signatureMethod= signatureMethod;
   this._nonceSize= nonceSize || 32;
@@ -49,7 +49,7 @@ exports.OAuthEcho= function(realm, verify_credentials, consumerKey, consumerSecr
   }
   this._version= version;
 
-  if( signatureMethod != "PLAINTEXT" && signatureMethod != "HMAC-SHA1" && signatureMethod != "RSA-SHA1")
+  if( signatureMethod != "PLAINTEXT" && signatureMethod != "HMAC-SHA1" && signatureMethod != "HMAC-SHA256" && signatureMethod != "RSA-SHA1")
     throw new Error("Un-supported signature method: " + signatureMethod );
   this._signatureMethod= signatureMethod;
   this._nonceSize= nonceSize || 32;
@@ -210,7 +210,9 @@ exports.OAuth.prototype._createSignature= function(signatureBase, tokenSecret) {
      key = this._privateKey || "";
      hash= crypto.createSign("RSA-SHA1").update(signatureBase).sign(key, 'base64');
    }
-   else {
+   else if (this._signatureMethod == "HMAC-SHA256"){
+     hash = crypto.createHmac("sha256", key).update(signatureBase).digest("base64");
+   } else {
        if( crypto.Hmac ) {
          hash = crypto.createHmac("sha1", key).update(signatureBase).digest("base64");
        }


### PR DESCRIPTION
I hadded support for HMAC-SHA256 encoding to accomodate magento2 oauth1 (https://developer.adobe.com/commerce/webapi/get-started/authentication/gs-authentication-oauth/)